### PR TITLE
Implement a depth limit so that highly-nested objects don't cause a segfault (when decoding with _speedups)

### DIFF
--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -30,6 +30,7 @@ def all_tests_suite():
         'simplejson.tests.test_check_circular',
         'simplejson.tests.test_decode',
         'simplejson.tests.test_default',
+        'simplejson.tests.test_depthlimit',
         'simplejson.tests.test_dump',
         'simplejson.tests.test_encode_basestring_ascii',
         'simplejson.tests.test_encode_for_html',

--- a/simplejson/tests/test_depthlimit.py
+++ b/simplejson/tests/test_depthlimit.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+import simplejson as json
+from simplejson.scanner import JSON_TOKENER_MAX_DEPTH as MAX
+
+OK = MAX - 1
+
+class TestDepthLimit(TestCase):
+    def _assertExceedsDepth(self, *args, **kwargs):
+        try:
+            json.loads(*args, **kwargs)
+        except json.JSONDecodeError, exc:
+            self.assertTrue(str(exc).startswith('Depth limit exceeded: line '))
+        except Exception, exc:
+            self.fail("json.loads raised %r instead of JSONDecodeError" % (exc,))
+        else:
+            self.fail("json.loads did not raise JSONDecodeError")
+
+    def test_depthLimitStringArray(self):
+        json.loads('[' * OK + '1' + ']' * OK)
+        self._assertExceedsDepth('[' * MAX + '1' + ']' * MAX)
+
+    def test_depthLimitUnicodeArray(self):
+        json.loads(u'[' * OK + u'1' + u']' * OK)
+        self._assertExceedsDepth(u'[' * MAX + u'1' + u']' * MAX)
+
+    def test_depthLimitStringObject(self):
+        json.loads('{"":' * OK + '1' + '}' * OK)
+        self._assertExceedsDepth('{"":' * MAX + '1' + '}' * MAX)
+        self._assertExceedsDepth('{"":' * OK + '[1]' + '}' * OK)
+
+    def test_depthLimitUnicodeObject(self):
+        json.loads(u'{"":' * OK + u'1' + u'}' * OK)
+        self._assertExceedsDepth(u'{"":' * MAX + u'1' + u'}' * MAX)
+        self._assertExceedsDepth(u'{"":' * OK + u'[1]' + u'}' * OK)


### PR DESCRIPTION
My fork prevents inputs like this from causing a segfault:

```
# python -c "import simplejson; simplejson.loads('[' * 100000 + '1' + ']' * 100000)"
zsh: segmentation fault  python -c

# python -c "import simplejson; simplejson.loads('{\"a\":' * 100000 + '1' + '}' * 100000)"
zsh: segmentation fault  python -c
```

There might still be a few issues:
1. Is is the depth limit of 32 high enough?
2. Do users need to be able to customize the depth limit?
3. Is raising `OverflowError` internally okay, or do I need to raise `JSONDecodeError`?
