### PR TITLE
Allow unknown numerical types for indent parameter

### DIFF
--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -171,7 +171,7 @@ class JSONEncoder(object):
         self.namedtuple_as_object = namedtuple_as_object
         self.tuple_as_array = tuple_as_array
         try:
-            indent = ' ' * indent
+            indent = indent * ' '
         except TypeError:
             pass
         self.indent = indent

--- a/simplejson/tests/test_dump.py
+++ b/simplejson/tests/test_dump.py
@@ -25,3 +25,43 @@ class TestDump(TestCase):
         items = [('one', 1), ('two', 2), ('three', 3), ('four', 4), ('five', 5)]
         s = json.dumps(json.OrderedDict(items))
         self.assertEqual(s, '{"one": 1, "two": 2, "three": 3, "four": 4, "five": 5}')
+
+    def test_indent_unknown_type_acceptance(self):
+        """
+        A test against the regression mentioned at `github issue 29`_.
+
+        The indent parameter should accept any type which pretends to be
+        an instance of int or long when it comes to being multiplied by
+        strings, even if it is not actually an int or long, for
+        backwards compatibility.
+
+        .. _github issue 29:
+           http://github.com/simplejson/simplejson/issue/29
+        """
+
+        class AwesomeInt(object):
+            """An awesome reimplementation of integers"""
+
+            def __init__(self, *args, **kwargs):
+                if len(args) > 0:
+                    # [construct from literals, objects, etc.]
+                    # ...
+
+                    # Finally, if args[0] is an integer, store it
+                    if isinstance(args[0], int):
+                        self._int = args[0]
+
+            # [various methods]
+
+            def __mul__(self, other):
+                # [various ways to multiply AwesomeInt objects]
+                # ... finally, if the right-hand operand is not awesome enough,
+                # try to do a normal integer multiplication
+                if hasattr(self, '_int'):
+                    return self._int * other
+                else:
+                    raise NotImplementedError("To do non-awesome things with"
+                        " this object, please construct it from an integer!")
+
+        s = json.dumps(range(3), indent=AwesomeInt(3))
+        self.assertEqual(s, '[\n   0,\n   1,\n   2\n]')


### PR DESCRIPTION
This was causing failures in software which passes objects which are
neither of type str, int, or long, but rather a custom numerical class,
as the value of the indent parameter. Since this custom numerical class
understands multiplication by strings, it should be accepted by
simplejson's encoder and treated as a numerical argument.

... is what it says in the commit message. Of course, I make no such bold claim about what "should" happen, but am just submitting this pull request to see if you agree :) This is in some sense a regression because everything worked fine before string arguments for the indent parameter became supported, and the docstring suggests that backwards compatibility was aimed for.
