### PR TITLE
Bug fixes related to raw_decode()

### DIFF
--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -403,13 +403,13 @@ class JSONDecoder(object):
         instance containing a JSON document)
 
         """
-        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+        obj, end = self.raw_decode(s)
         end = _w(s, end).end()
         if end != len(s):
             raise JSONDecodeError("Extra data", s, end, len(s))
         return obj
 
-    def raw_decode(self, s, idx=0):
+    def raw_decode(self, s, idx=0, _w=WHITESPACE.match):
         """Decode a JSON document from ``s`` (a ``str`` or ``unicode``
         beginning with a JSON document) and return a 2-tuple of the Python
         representation and the index in ``s`` where the document ended.
@@ -421,7 +421,7 @@ class JSONDecoder(object):
 
         """
         try:
-            obj, end = self.scan_once(s, idx)
+            obj, end = self.scan_once(s, idx=_w(s, idx).end())
         except StopIteration:
             raise JSONDecodeError("No JSON object could be decoded", s, idx)
         return obj, end


### PR DESCRIPTION
Modify raw_decode() to allow white space before the object. The specification at json.org requires that white space before objects should be ignored, which includes the beginning of a JSON document.
