### PR TITLE
Using setuptools to allow the eggs creation with bdist_egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
 import sys
-from distutils.core import setup, Extension, Command
+import distutils
+from distutils.core import Command
+from distutils.core import Extension as _Extension
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
+from setuptools import setup
+
+distutils.command.build_ext.Extension = _Extension
+Extension = _Extension
 
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
 VERSION = '2.6.2'


### PR DESCRIPTION
This commit changes the way setup is imported in setup.py. Using setuptools instead of distutils lets you create Python eggs with 

python setup bdist_egg

I also had to override the Extension declaration because it's automatically overriden by setuptools and can't be used further as it is.
