### PR TITLE
fix pickle breakage with JSONDecodeError

### DIFF
--- a/simplejson/scanner.py
+++ b/simplejson/scanner.py
@@ -41,6 +41,9 @@ class JSONDecodeError(ValueError):
         else:
             self.endlineno, self.endcolno = None, None
 
+    def __reduce__(self):
+        return self.__class__, (self.msg, self.doc, self.pos, self.end)
+
 
 def linecol(doc, pos):
     lineno = doc.count('\n', 0, pos) + 1

--- a/simplejson/tests/test_errors.py
+++ b/simplejson/tests/test_errors.py
@@ -1,4 +1,4 @@
-import sys
+import sys, pickle
 from unittest import TestCase
 
 import simplejson as json
@@ -33,3 +33,19 @@ class TestErrors(TestCase):
                 self.fail('Expected JSONDecodeError')
             self.assertEqual(err.lineno, 1)
             self.assertEqual(err.colno, 10)
+
+    def test_error_is_pickable(self):
+        err = None
+        try:
+            json.loads('{}\na\nb')
+        except json.JSONDecodeError:
+            err = sys.exc_info()[1]
+        else:
+            self.fail('Expected JSONDecodeError')
+        s = pickle.dumps(err)
+        e = pickle.loads(s)
+
+        self.assertEquals(err.msg, e.msg)
+        self.assertEquals(err.doc, e.doc)
+        self.assertEquals(err.pos, e.pos)
+        self.assertEquals(err.end, e.end)


### PR DESCRIPTION
pickle doesn't behave correctly with custom Exceptions, we workaround the issue
by explicitly defining how to pickle JSONDecodeError.
