### PR TITLE
_speedups.c fails to compile with msvc

### DIFF
--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -663,11 +663,12 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
     else if (PyInt_Check(key) || PyLong_Check(key)) {
         if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
             /* See #118, do not trust custom str/repr */
+            PyObject *res;
             PyObject *tmp = PyObject_CallFunctionObjArgs((PyObject *)&PyLong_Type, key, NULL);
             if (tmp == NULL) {
                 return NULL;
             }
-            PyObject *res = PyObject_Str(tmp);
+            res = PyObject_Str(tmp);
             Py_DECREF(tmp);
             return res;
         }
@@ -2818,11 +2819,12 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     }
     else {
         /* See #118, do not trust custom str/repr */
+        PyObject *res;
         PyObject *tmp = PyObject_CallFunctionObjArgs((PyObject *)&PyFloat_Type, obj, NULL);
         if (tmp == NULL) {
             return NULL;
         }
-        PyObject *res = PyObject_Repr(tmp);
+        res = PyObject_Repr(tmp);
         Py_DECREF(tmp);
         return res;
     }


### PR DESCRIPTION
Fixes `msvc error C2275: 'PyObject' : illegal use of this type as an expression`
```
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG  -IX:\Python27\include -IX:\Python27\PC /Tcsimplejson/_speedups.c /Fobuild\temp.win32-2.7\Release\simplejson/_speedups.obj
_speedups.c
simplejson/_speedups.c(670) : error C2275: 'PyObject' : illegal use of this type as an expression
        x:\python27\include\object.h(108) : see declaration of 'PyObject'
simplejson/_speedups.c(670) : error C2065: 'res' : undeclared identifier
simplejson/_speedups.c(672) : error C2065: 'res' : undeclared identifier
simplejson/_speedups.c(672) : warning C4047: 'return' : 'PyObject *' differs in levels of indirection from 'int'
simplejson/_speedups.c(2654) : warning C4018: '<' : signed/unsigned mismatch
simplejson/_speedups.c(2825) : error C2275: 'PyObject' : illegal use of this type as an expression
        x:\python27\include\object.h(108) : see declaration of 'PyObject'
simplejson/_speedups.c(2825) : error C2065: 'res' : undeclared identifier
simplejson/_speedups.c(2827) : error C2065: 'res' : undeclared identifier
simplejson/_speedups.c(2827) : warning C4047: 'return' : 'PyObject *' differs in levels of indirection from 'int'
```