### PR TITLE
Add iterable as array encoding option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Version 2.3.0 released 2011-XX-XX
+
+* New iterable_as_array encoder option to perform lazy serialization of
+  any iterable objects, without having to convert to tuple or list.
+
 Version 2.2.0 released 2011-09-04
 
 * Remove setuptools requirement, reverted to pure distutils

--- a/conf.py
+++ b/conf.py
@@ -42,9 +42,9 @@ copyright = '2011, Bob Ippolito'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '2.2'
+version = '2.3'
 # The full version, including alpha/beta/rc tags.
-release = '2.2.0'
+release = '2.3.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/index.rst
+++ b/index.rst
@@ -129,7 +129,7 @@ Using :mod:`simplejson.tool` from the shell to validate and pretty-print::
 Basic Usage
 -----------
 
-.. function:: dump(obj, fp[, skipkeys[, ensure_ascii[, check_circular[, allow_nan[, cls[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array[, **kw]]]]]]]]]]]]])
+.. function:: dump(obj, fp[, skipkeys[, ensure_ascii[, check_circular[, allow_nan[, cls[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array[, iterable_as_array[, **kw]]]]]]]]]]]]]])
 
    Serialize *obj* as a JSON formatted stream to *fp* (a ``.write()``-supporting
    file-like object).
@@ -192,7 +192,7 @@ Basic Usage
   If *namedtuple_as_object* is true (default: ``True``),
   :class:`tuple` subclasses with ``_asdict()`` methods will be encoded
   as JSON objects.
-  
+
   .. versionchanged:: 2.2.0
     *namedtuple_as_object* is new in 2.2.0.
 
@@ -202,6 +202,14 @@ Basic Usage
   .. versionchanged:: 2.2.0
     *tuple_as_array* is new in 2.2.0.
 
+  If *iterable_as_array* is true (default: ``False``),
+  any object not in the above table that implements ``__iter__()``
+  will be encoded as a JSON array.
+
+  .. versionchanged:: 2.3.0
+    *iterable_as_array* is new in 2.3.0.
+
+
     .. note::
 
         JSON is not a framed protocol so unlike :mod:`pickle` or :mod:`marshal` it
@@ -209,7 +217,7 @@ Basic Usage
         container protocol to delimit them.
 
 
-.. function:: dumps(obj[, skipkeys[, ensure_ascii[, check_circular[, allow_nan[, cls[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array[, **kw]]]]]]]]]]]]])
+.. function:: dumps(obj[, skipkeys[, ensure_ascii[, check_circular[, allow_nan[, cls[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array[, iterable_as_array[, **kw]]]]]]]]]]]]]])
 
    Serialize *obj* to a JSON formatted :class:`str`.
 
@@ -273,6 +281,14 @@ Basic Usage
 
    .. versionchanged:: 2.1.0
       *use_decimal* is new in 2.1.0.
+
+   If *iterable_as_array* is true (default: ``False``),
+   any object not in the above table that implements ``__iter__()``
+   will be encoded as a JSON array.
+
+   .. versionchanged:: 2.3.0
+     *iterable_as_array* is new in 2.3.0.
+
 
    To use a custom :class:`JSONDecoder` subclass, specify it with the ``cls``
    kwarg.  Additional keyword arguments will be passed to the constructor of the
@@ -406,7 +422,7 @@ Encoders and decoders
       :exc:`JSONDecodeError` will be raised if the given JSON
       document is not valid.
 
-.. class:: JSONEncoder([skipkeys[, ensure_ascii[, check_circular[, allow_nan[, sort_keys[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array]]]]]]]]]]]])
+.. class:: JSONEncoder([skipkeys[, ensure_ascii[, check_circular[, allow_nan[, sort_keys[, indent[, separators[, encoding[, default[, use_decimal[, namedtuple_as_object[, tuple_as_array[, iterable_as_array]]]]]]]]]]]]])
 
    Extensible JSON encoder for Python data structures.
 
@@ -495,6 +511,13 @@ Encoders and decoders
 
    .. versionchanged:: 2.2.0
      *tuple_as_array* is new in 2.2.0.
+
+   If *iterable_as_array* is true (default: ``False``),
+   any object not in the above table that implements ``__iter__()``
+   will be encoded as a JSON array.
+
+   .. versionchanged:: 2.3.0
+     *iterable_as_array* is new in 2.3.0.
 
    .. method:: default(o)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
-VERSION = '2.2.0'
+VERSION = '2.3.0'
 DESCRIPTION = "Simple, fast, extensible JSON encoder/decoder for Python"
 LONG_DESCRIPTION = open('README.rst', 'r').read()
 
@@ -36,13 +36,13 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError, x:
+        except DistutilsPlatformError:
             raise BuildFailed()
 
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except ext_errors, x:
+        except ext_errors:
             raise BuildFailed()
 
 

--- a/simplejson/tests/test_iterable.py
+++ b/simplejson/tests/test_iterable.py
@@ -1,0 +1,31 @@
+import unittest
+from StringIO import StringIO
+
+import simplejson as json
+
+def iter_dumps(obj, **kw):
+    return ''.join(json.JSONEncoder(**kw).iterencode(obj))
+
+def sio_dump(obj, **kw):
+    sio = StringIO()
+    json.dumps(obj, **kw)
+    return sio.getvalue()
+
+class TestIterable(unittest.TestCase):
+    def test_iterable(self):
+        l = [1, 2, 3]
+        for dumps in (json.dumps, iter_dumps, sio_dump):
+            expect = dumps(l)
+            default_expect = dumps(sum(l))
+            # Default is False
+            self.assertRaises(TypeError, dumps, iter(l))
+            self.assertRaises(TypeError, dumps, iter(l), iterable_as_array=False)
+            self.assertEqual(expect, dumps(iter(l), iterable_as_array=True))
+            # Ensure that the "default" gets called
+            self.assertEqual(default_expect, dumps(iter(l), default=sum))
+            self.assertEqual(default_expect, dumps(iter(l), iterable_as_array=False, default=sum))
+            # Ensure that the "default" does not get called
+            self.assertEqual(
+                default_expect,
+                dumps(iter(l), iterable_as_array=True, default=sum))
+        

--- a/simplejson/tests/test_tuple.py
+++ b/simplejson/tests/test_tuple.py
@@ -43,7 +43,3 @@ class TestTuples(unittest.TestCase):
         self.assertEqual(
             json.dumps(repr(t)),
             sio.getvalue())
-
-class TestNamedTuple(unittest.TestCase):
-    def test_namedtuple_dump(self):
-        pass


### PR DESCRIPTION
This pull request takes the work done in the [`iterable_as_array`](https://github.com/simplejson/simplejson/tree/49724ee06f038d27ab3d4adbe4ed403692799aa1) branch and merges it into master. As discussed in #1, this allows for simplejson to encode generators of arbitrary length with little memory usage when paired with `encoder.iterencode` -- without resorting to subclassing `list` (ie. iterators just work now).

Not implemented in this pull request, but might be useful, is changing the documentation on the [`default`](https://simplejson.readthedocs.org/en/latest/index.html?highlight=default#simplejson.JSONEncoder.default) parameter. Quoting the documentation for convenience: 

>For example, to support arbitrary iterators, you could implement default like this:
>
>```python
>def default(self, o):
>   try:
>       iterable = iter(o)
>   except TypeError:
>       pass
>   else:
>       return list(iterable)
>   return JSONEncoder.default(self, o)
>```

Either the example should be changed, or mentioned that arbitrary iterators are supported with the `iterable_as_array` parameter

Let me know if there is anything I can do to improve the pull request.

Closes #1