### PR TITLE
add build status badge and github-visible python2.2 link to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+simplejson
+----------
+
+.. image:: https://travis-ci.org/simplejson/simplejson.svg?branch=master
+    :target: https://travis-ci.org/simplejson/simplejson
+
 simplejson is a simple, fast, complete, correct and extensible
 JSON <http://json.org> encoder and decoder for Python 2.5+
 and Python 3.3+.  It is pure Python code with no dependencies,
@@ -27,3 +33,4 @@ Python 2.2. This is based off of a very old version of simplejson,
 is not maintained, and should only be used as a last resort.
 
 .. _python2.2: https://github.com/simplejson/simplejson/tree/python2.2
+https://github.com/simplejson/simplejson/tree/python2.2


### PR DESCRIPTION
I realize that this might not be what y'all want and I am totally it ok with it not being merged. 

It was useful to me to be able to see the link to https://github.com/simplejson/simplejson/tree/python2.2 from the github UI which does not accurately display all .rst markup. 

The build status badge from travis is useful mostly as a brag I think and maybe it isn't wanted in built docs. I see it as a nice piece of reassurance that a project is not in a bad state. 