### PR TITLE
Failing tests about streaming parsing with split multibyte characters.

### DIFF
--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -50,6 +50,7 @@ def all_tests_suite():
                 'simplejson.tests.test_float',
                 'simplejson.tests.test_indent',
                 'simplejson.tests.test_iterable',
+                'simplejson.tests.test_multibyte',
                 'simplejson.tests.test_pass1',
                 'simplejson.tests.test_pass2',
                 'simplejson.tests.test_pass3',

--- a/simplejson/tests/test_multibyte.py
+++ b/simplejson/tests/test_multibyte.py
@@ -1,0 +1,42 @@
+# coding=UTF-8
+
+from __future__ import absolute_import
+from unittest import TestCase
+
+import simplejson as json
+
+
+class ReadChunkedFile(object):
+    '''A file whose reads come in predefined chunks.'''
+    def __init__(self, *pieces):
+        self.pieces = iter(pieces)
+
+    def read(self):
+        try:
+            return next(self.pieces)
+        except StopIteration:
+            return ''
+
+
+class TestMultibyte(TestCase):
+    if not hasattr(TestCase, 'assertIs'):
+        def assertIs(self, a, b):
+            self.assertTrue(a is b, '%r is %r' % (a, b))
+
+    def test_load_with_split_unicode(self):
+        # These together produce JSON-encoded 'ü'
+        first, second = '"\\u00', 'fc"'
+        self.assertEqual(u'ü', json.loads(first + second))
+
+        # This is the content split over two successive reads
+        fin = ReadChunkedFile(first, second)
+        self.assertEqual(u'ü', json.load(fin))
+
+    def test_load_with_split_utf8(self):
+        # These together produce JSON-encoded 'ü'
+        first, second = '"\xC3', '\xBC"'
+        self.assertEqual(u'ü', json.loads(first + second))
+
+        # This is the content split over two successive reads
+        fin = ReadChunkedFile(first, second)
+        self.assertEqual(u'ü', json.load(fin))


### PR DESCRIPTION
When streaming JSON from a file-like object, it's possible for two successive reads to happen to split a multibyte character. In that case, remaining bytes must be read before attempting to interpret the sequence correctly.

For example, ü is encoded as \u00fc. If \u00 should appear in one read, and the fc in the next, the current implementation attempts to interpret \u00, throwing an exception:

```
Traceback (most recent call last):
  File "/Users/dan/moz/simplejson/simplejson/tests/test_multibyte.py", line 33, in test_load_with_split_unicode
    self.assertEqual(u'ü', json.load(fin))
  File "/Users/dan/moz/simplejson/simplejson/__init__.py", line 459, in load
    use_decimal=use_decimal, **kw)
  File "/Users/dan/moz/simplejson/simplejson/__init__.py", line 516, in loads
    return _default_decoder.decode(s)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
  File "/Users/dan/moz/simplejson/simplejson/scanner.py", line 127, in scan_once
    return _scan_once(string, idx)
  File "/Users/dan/moz/simplejson/simplejson/scanner.py", line 90, in _scan_once
    return parse_string(string, idx + 1, encoding, strict)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 107, in py_scanstring
    raise JSONDecodeError(msg, s, end - 1)
JSONDecodeError: Invalid \uXXXX escape sequence: line 1 column 2 (char 1)
```

There's a similar problem when encoded as UTF-8. In that case, it's `\xC3` and `\xBC`, producing the following stack trace:

```
Traceback (most recent call last):
  File "/Users/dan/moz/simplejson/simplejson/tests/test_multibyte.py", line 42, in test_load_with_split_utf8
    self.assertEqual(u'ü', json.load(fin))
  File "/Users/dan/moz/simplejson/simplejson/__init__.py", line 459, in load
    use_decimal=use_decimal, **kw)
  File "/Users/dan/moz/simplejson/simplejson/__init__.py", line 516, in loads
    return _default_decoder.decode(s)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
  File "/Users/dan/moz/simplejson/simplejson/scanner.py", line 127, in scan_once
    return _scan_once(string, idx)
  File "/Users/dan/moz/simplejson/simplejson/scanner.py", line 90, in _scan_once
    return parse_string(string, idx + 1, encoding, strict)
  File "/Users/dan/moz/simplejson/simplejson/decoder.py", line 69, in py_scanstring
    "Unterminated string starting at", s, begin)
JSONDecodeError: Unterminated string starting at: line 1 column 1 (char 0)
```

@vadim-moz mentioned this is a problem in some JSON implementations, which spurred my curiosity. Also, @benkirzhner, @sistawendy, and @b4hand may be interested.