### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -318,7 +318,7 @@ Version 2.2.0 released 2011-09-04
 * Force unicode linebreak characters to be escaped (U+2028 and U+2029)
   http://timelessrepo.com/json-isnt-a-javascript-subset
 * Moved documentation from a git submodule to
-  http://simplejson.readthedocs.org/
+  https://simplejson.readthedocs.io/
 
 Version 2.1.6 released 2011-05-08
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ and Python 3.3+.  It is pure Python code with no dependencies,
 but includes an optional C extension for a serious speed boost.
 
 The latest documentation for simplejson can be read online here:
-http://simplejson.readthedocs.org/
+https://simplejson.readthedocs.io/
 
 simplejson is the externally maintained development version of the
 json library included with Python 2.6 and Python 3.0, but maintains


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.