### PR TITLE
Support preprocessed json strings (with optimizations) in encoder

### DIFF
--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -101,7 +101,7 @@ __version__ = '3.8.2'
 __all__ = [
     'dump', 'dumps', 'load', 'loads',
     'JSONDecoder', 'JSONDecodeError', 'JSONEncoder',
-    'OrderedDict', 'simple_first',
+    'OrderedDict', 'simple_first', 'json_str'
 ]
 
 __author__ = 'Bob Ippolito <bob@redivi.com>'
@@ -119,6 +119,9 @@ def _import_OrderedDict():
         from . import ordered_dict
         return ordered_dict.OrderedDict
 OrderedDict = _import_OrderedDict()
+
+class json_str(str):
+    is_json = True
 
 def _import_c_make_encoder():
     try:

--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -143,6 +143,7 @@ _default_encoder = JSONEncoder(
     bigint_as_string=False,
     item_sort_key=None,
     for_json=False,
+    is_json=False,
     ignore_nan=False,
     int_as_string_bitcount=None,
 )
@@ -152,7 +153,7 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
          encoding='utf-8', default=None, use_decimal=True,
          namedtuple_as_object=True, tuple_as_array=True,
          bigint_as_string=False, sort_keys=False, item_sort_key=None,
-         for_json=False, ignore_nan=False, int_as_string_bitcount=None,
+         for_json=False, is_json=False, ignore_nan=False, int_as_string_bitcount=None,
          iterable_as_array=False, **kw):
     """Serialize ``obj`` as a JSON formatted stream to ``fp`` (a
     ``.write()``-supporting file-like object).
@@ -231,6 +232,11 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
     method will use the return value of that method for encoding as JSON
     instead of the object.
 
+    If *is_json* is true (default: ``False``), objects with a ``is_json``
+    attribute will not be processed or escaped. The value will be treated
+    as if it was already processed by a json encoder. However, it will be
+    converted to ``encoding``.
+
     If *ignore_nan* is true (default: ``False``), then out of range
     :class:`float` values (``nan``, ``inf``, ``-inf``) will be serialized as
     ``null`` in compliance with the ECMA-262 specification. If true, this will
@@ -249,7 +255,7 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
         encoding == 'utf-8' and default is None and use_decimal
         and namedtuple_as_object and tuple_as_array and not iterable_as_array
         and not bigint_as_string and not sort_keys
-        and not item_sort_key and not for_json
+        and not item_sort_key and not for_json and not is_json
         and not ignore_nan and int_as_string_bitcount is None
         and not kw
     ):
@@ -268,6 +274,7 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
             sort_keys=sort_keys,
             item_sort_key=item_sort_key,
             for_json=for_json,
+            is_json=is_json,
             ignore_nan=ignore_nan,
             int_as_string_bitcount=int_as_string_bitcount,
             **kw).iterencode(obj)
@@ -282,7 +289,7 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
           encoding='utf-8', default=None, use_decimal=True,
           namedtuple_as_object=True, tuple_as_array=True,
           bigint_as_string=False, sort_keys=False, item_sort_key=None,
-          for_json=False, ignore_nan=False, int_as_string_bitcount=None,
+          for_json=False, is_json=False, ignore_nan=False, int_as_string_bitcount=None,
           iterable_as_array=False, **kw):
     """Serialize ``obj`` to a JSON formatted ``str``.
 
@@ -355,6 +362,11 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
     method will use the return value of that method for encoding as JSON
     instead of the object.
 
+    If *is_json* is true (default: ``False``), objects with a ``is_json``
+    attribute will not be processed or escaped. The value will be treated
+    as if it was already processed by a json encoder. However, it will be
+    converted to ``encoding``.
+
     If *ignore_nan* is true (default: ``False``), then out of range
     :class:`float` values (``nan``, ``inf``, ``-inf``) will be serialized as
     ``null`` in compliance with the ECMA-262 specification. If true, this will
@@ -373,7 +385,7 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
         encoding == 'utf-8' and default is None and use_decimal
         and namedtuple_as_object and tuple_as_array and not iterable_as_array
         and not bigint_as_string and not sort_keys
-        and not item_sort_key and not for_json
+        and not item_sort_key and not for_json and not is_json
         and not ignore_nan and int_as_string_bitcount is None
         and not kw
     ):
@@ -392,6 +404,7 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
         sort_keys=sort_keys,
         item_sort_key=item_sort_key,
         for_json=for_json,
+        is_json=is_json,
         ignore_nan=ignore_nan,
         int_as_string_bitcount=int_as_string_bitcount,
         **kw).encode(obj)

--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -63,6 +63,7 @@ def all_tests_suite():
                 'simplejson.tests.test_namedtuple',
                 'simplejson.tests.test_tool',
                 'simplejson.tests.test_for_json',
+                'simplejson.tests.test_is_json',
                 'simplejson.tests.test_subclass',
             ]))
     suite = get_suite()

--- a/simplejson/tests/test_is_json.py
+++ b/simplejson/tests/test_is_json.py
@@ -1,10 +1,6 @@
 import unittest
 import simplejson as json
 
-
-class json_str(str):
-    is_json = True
-
 dct1 = {
     'key1': 'value1'
 }
@@ -16,7 +12,7 @@ dct2 = {
 
 dct3 = {
     'key2': 'value2',
-    'd1': json_str(json.dumps(dct1))
+    'd1': json.json_str(json.dumps(dct1))
 }
 
 

--- a/simplejson/tests/test_is_json.py
+++ b/simplejson/tests/test_is_json.py
@@ -1,0 +1,29 @@
+import unittest
+import simplejson as json
+
+
+class json_str(str):
+    is_json = True
+
+dct1 = {
+    'key1': 'value1'
+}
+
+dct2 = {
+    'key2': 'value2',
+    'd1': dct1
+}
+
+dct3 = {
+    'key2': 'value2',
+    'd1': json_str(json.dumps(dct1))
+}
+
+
+class TestIsJson(unittest.TestCase):
+
+    def test_is_json_ignored_by_default(self):
+        self.assertNotEqual(json.dumps(dct2), json.dumps(dct3))
+
+    def test_is_json(self):
+        self.assertEqual(json.dumps(dct2), json.dumps(dct3, is_json=True))


### PR DESCRIPTION
Similar to issue #125.

There are situations when you may have a dictionary with some key/value pair such that the value is a large json string. In order to encode the entire dictionary as a single json string you currently have to parse and re-encode the those values which can hurt performance for large enough objects. I put this together to allow raw json values to pass through (they will still be converted to correct character encoding) while still using the C optimizations where possible.

I would love feedback if there is a more appropriate way to address this, but I wanted to at least put something together to get it going. This is also my first foray into python C extensions so I tried to carefully check my usage of INCREF/DECREF but there are likely still mistakes.