### PR TITLE
Add support for preprocessed JSON strings (with optimizations) in encoder

### DIFF
--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -110,7 +110,7 @@ from decimal import Decimal
 
 from .scanner import JSONDecodeError
 from .decoder import JSONDecoder
-from .encoder import JSONEncoder, JSONEncoderForHTML
+from .encoder import JSONEncoder, JSONEncoderForHTML, json_str
 def _import_OrderedDict():
     import collections
     try:

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -292,7 +292,7 @@ static int is_json_type(PyObject *pystr)
         if (JsonStrType == NULL)
             return 0;
     }
-    if (PyObject_isInstance(pystr, JsonStrType))
+    if (PyObject_IsInstance(pystr, JsonStrType))
         return 1;
 
 #if PY_MAJOR_VERSION < 3
@@ -303,7 +303,7 @@ static int is_json_type(PyObject *pystr)
         if (JsonUniType == NULL)
             return 0;
     }
-    if (PyObject_isInstance(pystr, JsonUniType))
+    if (PyObject_IsInstance(pystr, JsonUniType))
         return 1;
 #endif /* PY_MAJOR_VERSION < 3 */
 

--- a/simplejson/tests/test_json_str.py
+++ b/simplejson/tests/test_json_str.py
@@ -1,0 +1,30 @@
+import unittest
+import simplejson as json
+
+dct1 = {
+    'key1': 'value1'
+}
+
+dct2 = {
+    'key2': 'value2',
+    'd1': dct1
+}
+
+dct3 = {
+    'key2': 'value2',
+    'd1': json.dumps(dct1)
+}
+
+dct4 = {
+    'key2': 'value2',
+    'd1': json.json_str(json.dumps(dct1))
+}
+
+
+class TestIsJson(unittest.TestCase):
+
+    def test_normal_str(self):
+        self.assertNotEqual(json.dumps(dct2), json.dumps(dct3))
+
+    def test_json_str(self):
+        self.assertEqual(json.dumps(dct2), json.dumps(dct4))


### PR DESCRIPTION
Fixes #125 

In some situations, you may have a large python dictionary you need to JSONify but one of the values inside the dict is already a JSON string. This is common when pulling an object from a database, for example, where one of the fields is a JSON blob/string. Previously you would have to deserialize and then re-serialize that string just to serialize the high level object, but obviously this is unnecessarily slow. This changes adds a method/type that can be used to wrap a str and tell the serializer to just pass it through instead.

Original attempt was #141 but this should be a little cleaner.