### PR TITLE
Fix problems identified by `-3` flag when running in Python 2.7

### DIFF
--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -1,5 +1,6 @@
 """Python 3 compatibility shims
 """
+import codecs
 import sys
 if sys.version_info[0] < 3:
     PY3 = False
@@ -15,8 +16,9 @@ if sys.version_info[0] < 3:
     integer_types = (int, long)
     unichr = unichr
     reload_module = reload
+    __decode_hex = codecs.getdecoder('hex_codec')
     def fromhex(s):
-        return s.decode('hex')
+        return __decode_hex(s)[0]
 
 else:
     PY3 = True
@@ -24,7 +26,6 @@ else:
         from importlib import reload as reload_module
     else:
         from imp import reload as reload_module
-    import codecs
     def b(s):
         return codecs.latin_1_encode(s)[0]
     def u(s):

--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -15,8 +15,12 @@ if sys.version_info[0] < 3:
     integer_types = (int, long)
     unichr = unichr
     reload_module = reload
-    import binascii
-    fromhex = binascii.unhexlify
+    try:
+        from binascii import unhexlify as fromhex
+    except ImportError:
+        # Python 2.5
+        def fromhex(s):
+            return s.decode('hex')
 
 else:
     PY3 = True

--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -1,6 +1,5 @@
 """Python 3 compatibility shims
 """
-import codecs
 import sys
 if sys.version_info[0] < 3:
     PY3 = False
@@ -16,9 +15,8 @@ if sys.version_info[0] < 3:
     integer_types = (int, long)
     unichr = unichr
     reload_module = reload
-    __decode_hex = codecs.getdecoder('hex_codec')
-    def fromhex(s):
-        return __decode_hex(s)[0]
+    import binascii
+    fromhex = binascii.unhexlify
 
 else:
     PY3 = True
@@ -26,6 +24,7 @@ else:
         from importlib import reload as reload_module
     else:
         from imp import reload as reload_module
+    import codecs
     def b(s):
         return codecs.latin_1_encode(s)[0]
     def u(s):

--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -15,13 +15,6 @@ if sys.version_info[0] < 3:
     integer_types = (int, long)
     unichr = unichr
     reload_module = reload
-    try:
-        from binascii import unhexlify as fromhex
-    except ImportError:
-        # Python 2.5
-        def fromhex(s):
-            return s.decode('hex')
-
 else:
     PY3 = True
     if sys.version_info[:2] >= (3, 4):
@@ -43,8 +36,5 @@ else:
 
     def unichr(s):
         return u(chr(s))
-
-    def fromhex(s):
-        return bytes.fromhex(s)
 
 long_type = integer_types[-1]

--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import re
 import sys
 import struct
-from .compat import fromhex, b, u, text_type, binary_type, PY3, unichr
+from .compat import b, u, text_type, binary_type, PY3, unichr
 from .scanner import make_scanner, JSONDecodeError
 
 def _import_c_scanstring():
@@ -22,12 +22,16 @@ __all__ = ['JSONDecoder']
 FLAGS = re.VERBOSE | re.MULTILINE | re.DOTALL
 
 def _floatconstants():
-    _BYTES = fromhex('7FF80000000000007FF0000000000000')
-    # The struct module in Python 2.4 would get frexp() out of range here
-    # when an endian is specified in the format string. Fixed in Python 2.5+
-    if sys.byteorder != 'big':
-        _BYTES = _BYTES[:8][::-1] + _BYTES[8:][::-1]
-    nan, inf = struct.unpack('dd', _BYTES)
+    if sys.version_info < (2, 6):
+        _BYTES = '7FF80000000000007FF0000000000000'.decode('hex')
+        # The struct module in Python 2.4 would get frexp() out of range here
+        # when an endian is specified in the format string. Fixed in Python 2.5+
+        if sys.byteorder != 'big':
+            _BYTES = _BYTES[:8][::-1] + _BYTES[8:][::-1]
+        nan, inf = struct.unpack('dd', _BYTES)
+    else:
+        nan = float('nan')
+        inf = float('inf')
     return nan, inf, -inf
 
 NaN, PosInf, NegInf = _floatconstants()


### PR DESCRIPTION
I am investigating a migration to Python 3, and to facilitate this we are using the `-3` flag as decribed here:
https://docs.python.org/3/howto/pyporting.html#prevent-compatibility-regressions .  When using this flag,
I get warnings from simplejson about the use of decode.

While obviously this is a invalid warning since this code is gated in Python 2, committing this change
will allow users to run their code in `-3` mode in Python 2 without warnings from simplejson.

Microbenchmarking this change with `timeit` also reveals it's faster!

```py
>>> import timeit
>>> timeit.timeit("decode_hex('4f6c6567')[0]", setup="import codecs; decode_hex = codecs.getdecoder('hex_codec')")
0.6572110652923584
>>> timeit.timeit("'4f6c6567'.decode('hex')")
0.9076640605926514
```