### PR TITLE
Documentation: class -> dictionary

### DIFF
--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -406,7 +406,7 @@ def load(fp, encoding=None, cls=None, object_hook=None, parse_float=None,
         use_decimal=False, namedtuple_as_object=True, tuple_as_array=True,
         **kw):
     """Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
-    a JSON document) to a Python object.
+    a JSON document) to a Python dictionary.
 
     *encoding* determines the encoding used to interpret any
     :class:`str` objects decoded by this instance (``'utf-8'`` by
@@ -463,7 +463,7 @@ def loads(s, encoding=None, cls=None, object_hook=None, parse_float=None,
         parse_int=None, parse_constant=None, object_pairs_hook=None,
         use_decimal=False, **kw):
     """Deserialize ``s`` (a ``str`` or ``unicode`` instance containing a JSON
-    document) to a Python object.
+    document) to a Python dictionary.
 
     *encoding* determines the encoding used to interpret any
     :class:`str` objects decoded by this instance (``'utf-8'`` by


### PR DESCRIPTION
## Updating documentation

As `load` and `loads` only returns an object when called with `object_hook` I think it makes more sense to say "dictionary" here as that is the default. See code snipped below

```python
>>> import simplejson as json
>>> type(json.loads('{"x": 4}'))
<class 'dict'>
```

All-in-all this will be less confusing for newcomers, and advanced users still understands the function will return an object in case they pass `object_hook`.