### PR TITLE
Current JSON outputs for Infinity, -Infinity, and NaN are not valid JSON. New option to allow output them as String.

### DIFF
--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -139,6 +139,7 @@ class JSONEncoder(object):
                  indent=None, separators=None, encoding='utf-8', default=None,
                  use_decimal=True, namedtuple_as_object=True,
                  tuple_as_array=True, bigint_as_string=False,
+                 big_floats_as_string=False,
                  item_sort_key=None, for_json=False, ignore_nan=False,
                  int_as_string_bitcount=None, iterable_as_array=False):
         """Constructor for JSONEncoder, with sensible defaults.
@@ -203,6 +204,10 @@ class JSONEncoder(object):
         or lower than -2**53 will be encoded as strings. This is to avoid the
         rounding that happens in Javascript otherwise.
 
+        If big_floats_as_string is true (not the default), Infinity, -Infinity,
+        and NaN will be encoded as strings. This is to avoid the parser error
+        in valid JSON decoders.
+
         If int_as_string_bitcount is a positive number (n), then int of size
         greater than or equal to 2**n or lower than or equal to -2**n will be
         encoded as strings.
@@ -232,6 +237,7 @@ class JSONEncoder(object):
         self.tuple_as_array = tuple_as_array
         self.iterable_as_array = iterable_as_array
         self.bigint_as_string = bigint_as_string
+        self.big_floats_as_string = big_floats_as_string
         self.item_sort_key = item_sort_key
         self.for_json = for_json
         self.ignore_nan = ignore_nan
@@ -321,7 +327,7 @@ class JSONEncoder(object):
                 return _orig_encoder(o)
 
         def floatstr(o, allow_nan=self.allow_nan, ignore_nan=self.ignore_nan,
-                _repr=FLOAT_REPR, _inf=PosInf, _neginf=-PosInf):
+                _repr=FLOAT_REPR, _inf=PosInf, _neginf=-PosInf, big_floats_as_string=self.big_floats_as_string):
             # Check for specials. Note that this type of test is processor
             # and/or platform-specific, so do tests which don't depend on
             # the internals.
@@ -344,6 +350,8 @@ class JSONEncoder(object):
                 raise ValueError(
                     "Out of range float values are not JSON compliant: " +
                     repr(o))
+            elif big_floats_as_string:
+                text = self.encode(text)
 
             return text
 

--- a/simplejson/tests/test_float.py
+++ b/simplejson/tests/test_float.py
@@ -20,6 +20,10 @@ class TestFloat(TestCase):
         for f in (PosInf, NegInf, NaN):
             self.assertRaises(ValueError, json.dumps, f, allow_nan=False)
 
+    def test_big_floats_as_string(self):
+        for num in [NaN, PosInf, NegInf]:
+            self.assertEqual(repr(float(json.loads(json.dumps(num, big_floats_as_string=True)))), repr(num))
+
     def test_floats(self):
         for num in [1617161771.7650001, math.pi, math.pi**100,
                     math.pi**-100, 3.1]:


### PR DESCRIPTION
I added a big_floats_as_string boolean option to allow producing valid JSON String values in case of `Infinity`, `-Infinity` or `NaN`.

It allows to parse them with a `+` also in JavaScript.

Tests included.