### PR TITLE
setup.py: fix condition for build_ext exception types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ Programming Language :: Python :: Implementation :: PyPy
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines()))
 
-if sys.platform == 'win32' and sys.version_info > (2, 6):
+if sys.platform == 'win32' and sys.version_info < (2, 7):
    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
    # find the compiler
    # It can also raise ValueError http://bugs.python.org/issue7511


### PR DESCRIPTION
The comment states that IOError and ValueError can be thrown in Python 2.6. The referenced CPython issue supports this, it seems to have been resolved in version 2.7. However, the code seems to have the condition backwards, and will only catch IOError or ValueError in versions *greater* than 2.6.