### PR TITLE
bpo-31505: Fix an assertion failure in json, in case _json.make_encoder() received a bad encoder() argument.

### DIFF
--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -63,6 +63,7 @@ class TestEncode(TestCase):
     def test_bad_str_encoder(self):
         # Issue #31505: There shouldn't be an assertion failure in case
         # c_make_encoder() receives a bad encoder() argument.
+        import decimal
         def bad_encoder1(*args):
             return None
         enc = encoder.c_make_encoder(
@@ -80,9 +81,6 @@ class TestEncode(TestCase):
                 bad_encoder2, None, ': ', ', ',
                 False, False, False, {}, False, False, False,
                 None, None, 'utf-8', False, False, decimal.Decimal, False)
-        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
-                                               bad_encoder2, None, ': ', ', ',
-                                               False, False, False)
         self.assertRaises(ZeroDivisionError, enc, 'spam', 4)
 
     @skip_if_speedups_missing

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -60,6 +60,32 @@ class TestEncode(TestCase):
         )
 
     @skip_if_speedups_missing
+    def test_bad_str_encoder(self):
+        # Issue #31505: There shouldn't be an assertion failure in case
+        # c_make_encoder() receives a bad encoder() argument.
+        def bad_encoder1(*args):
+            return None
+        enc = encoder.c_make_encoder(
+                None, lambda obj: str(obj),
+                bad_encoder1, None, ': ', ', ',
+                False, False, False, {}, False, False, False,
+                None, None, 'utf-8', False, False, decimal.Decimal, False)
+        self.assertRaises(TypeError, enc, 'spam', 4)
+        self.assertRaises(TypeError, enc, {'spam': 42}, 4)
+
+        def bad_encoder2(*args):
+            1/0
+        enc = encoder.c_make_encoder(
+                None, lambda obj: str(obj),
+                bad_encoder2, None, ': ', ', ',
+                False, False, False, {}, False, False, False,
+                None, None, 'utf-8', False, False, decimal.Decimal, False)
+        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
+                                               bad_encoder2, None, ': ', ', ',
+                                               False, False, False)
+        self.assertRaises(ZeroDivisionError, enc, 'spam', 4)
+
+    @skip_if_speedups_missing
     def test_bad_bool_args(self):
         def test(name):
             encoder.JSONEncoder(**{name: BadBool()}).encode({})


### PR DESCRIPTION
Original patch by Oren Milman.

https://bugs.python.org/issue31505