### PR TITLE
Make TypeError messages contain type name instead of a repr.

### DIFF
--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -77,7 +77,8 @@ Specializing JSON object encoding::
     >>> def encode_complex(obj):
     ...     if isinstance(obj, complex):
     ...         return [obj.real, obj.imag]
-    ...     raise TypeError(repr(o) + " is not JSON serializable")
+    ...     raise TypeError('Object of type %s is not JSON serializable' %
+    ...                     obj.__class__.__name__)
     ...
     >>> json.dumps(2 + 1j, default=encode_complex)
     '[2.0, 1.0]'

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -680,7 +680,9 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
         Py_INCREF(Py_None);
         return Py_None;
     }
-    PyErr_SetString(PyExc_TypeError, "keys must be a string");
+    PyErr_Format(PyExc_TypeError,
+                 "keys must be str, int, float, bool or None, "
+                 "not %.100s", key->ob_type->tp_name);
     return NULL;
 }
 

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -258,7 +258,8 @@ class JSONEncoder(object):
                 return JSONEncoder.default(self, o)
 
         """
-        raise TypeError(repr(o) + " is not JSON serializable")
+        raise TypeError('Object of type %s is not JSON serializable' %
+                        o.__class__.__name__)
 
     def encode(self, o):
         """Return a JSON string representation of a Python data structure.
@@ -541,7 +542,8 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
         elif _skipkeys:
             key = None
         else:
-            raise TypeError("key " + repr(key) + " is not a string")
+            raise TypeError('keys must be str, int, float, bool or None, '
+                            'not %s' % key.__class__.__name__)
         return key
 
     def _iterencode_dict(dct, _current_indent_level):

--- a/simplejson/tests/test_errors.py
+++ b/simplejson/tests/test_errors.py
@@ -7,7 +7,24 @@ from simplejson.compat import u, b
 class TestErrors(TestCase):
     def test_string_keys_error(self):
         data = [{'a': 'A', 'b': (2, 4), 'c': 3.0, ('d',): 'D tuple'}]
-        self.assertRaises(TypeError, json.dumps, data)
+        try:
+            json.dumps(data)
+        except TypeError:
+            err = sys.exc_info()[1]
+        else:
+            self.fail('Expected TypeError')
+        self.assertEqual(str(err),
+                'keys must be str, int, float, bool or None, not tuple')
+
+    def test_not_serializable(self):
+        try:
+            json.dumps(json)
+        except TypeError:
+            err = sys.exc_info()[1]
+        else:
+            self.fail('Expected TypeError')
+        self.assertEqual(str(err),
+                'Object of type module is not JSON serializable')
 
     def test_decode_error(self):
         err = None


### PR DESCRIPTION
The failure depends on the type, not on the value of an object.

This combines CPython's issues [26623](https://bugs.python.org/issue26623) and [24641](https://bugs.python.org/issue24641).