### PR TITLE
Avoid copying strings when encoding

### DIFF
--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -52,7 +52,7 @@ def encode_basestring(s, _PY3=PY3, _q=u('"')):
     else:
         if isinstance(s, str) and HAS_UTF8.search(s) is not None:
             s = s.decode('utf-8')
-        if type(s) not in string_types:
+        if type(s) not in (str, unicode):
             if isinstance(s, str):
                 s = str.__str__(s)
             else:
@@ -74,7 +74,7 @@ def py_encode_basestring_ascii(s, _PY3=PY3):
     else:
         if isinstance(s, str) and HAS_UTF8.search(s) is not None:
             s = s.decode('utf-8')
-        if type(s) not in string_types:
+        if type(s) not in (str, unicode):
             if isinstance(s, str):
                 s = str.__str__(s)
             else:

--- a/simplejson/tests/test_str_subclass.py
+++ b/simplejson/tests/test_str_subclass.py
@@ -14,3 +14,8 @@ class TestStrSubclass(TestCase):
             self.assertEqual(
                 s,
                 simplejson.loads(simplejson.dumps(WonkyTextSubclass(s))))
+
+            self.assertEqual(
+                s,
+                simplejson.loads(simplejson.dumps(WonkyTextSubclass(s),
+                                                  ensure_ascii=False)))


### PR DESCRIPTION
d782561 introduced a performance regression which means that every string is copied during serialisation, when ensure_ascii is False.

Fixes https://github.com/simplejson/simplejson/issues/208

