### PR TITLE
Defer is_raw_json test

### DIFF
--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2860,12 +2860,6 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             if (encoded != NULL)
                 rv = _steal_accumulate(rval, encoded);
         }
-        else if (is_raw_json(obj))
-        {
-            PyObject *encoded = PyObject_GetAttrString(obj, "encoded_json");
-            if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded);
-        }
         else if (PyInt_Check(obj) || PyLong_Check(obj)) {
             PyObject *encoded;
             if (PyInt_CheckExact(obj) || PyLong_CheckExact(obj)) {
@@ -2930,6 +2924,12 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
         }
         else if (s->use_decimal && PyObject_TypeCheck(obj, (PyTypeObject *)s->Decimal)) {
             PyObject *encoded = PyObject_Str(obj);
+            if (encoded != NULL)
+                rv = _steal_accumulate(rval, encoded);
+        }
+        else if (is_raw_json(obj))
+        {
+            PyObject *encoded = PyObject_GetAttrString(obj, "encoded_json");
             if (encoded != NULL)
                 rv = _steal_accumulate(rval, encoded);
         }


### PR DESCRIPTION
I've spent a while comparing serialisation performance between `simplejson` and `json` (spoiler: simplejson is about 1.5x slower, on python 2.7.12), and I realised that simplejson's performance decreased by about 12% with simplejson 3.10.0 - in other words, with the introduction of RawJSON support. It turns out that the cost of doing `isinstance` on every object is non-trivial.

This PR is intended as a straw-man. It improves performance, but will of change behavior for things like classes which extend `RawJSON` *and* provide a `for_json` method (when `for_json` is enabled). That sounds to me like a bit of a funny thing to do, but maybe it's a usecase we need to support?

[I've not been able to find any documentation on the behavior of RawJSON.]
