### PR TITLE
Simplify the compatibility code.

### DIFF
--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -5,8 +5,6 @@ if sys.version_info[0] < 3:
     PY3 = False
     def b(s):
         return s
-    def u(s):
-        return unicode(s, 'unicode_escape')
     import cStringIO as StringIO
     StringIO = BytesIO = StringIO.StringIO
     text_type = unicode
@@ -21,11 +19,8 @@ else:
         from importlib import reload as reload_module
     else:
         from imp import reload as reload_module
-    import codecs
     def b(s):
-        return codecs.latin_1_encode(s)[0]
-    def u(s):
-        return s
+        return bytes(s, 'latin1')
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
@@ -33,8 +28,6 @@ else:
     binary_type = bytes
     string_types = (str,)
     integer_types = (int,)
-
-    def unichr(s):
-        return u(chr(s))
+    unichr = chr
 
 long_type = integer_types[-1]

--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import re
 import sys
 import struct
-from .compat import u, text_type, binary_type, PY3, unichr
+from .compat import PY3, unichr
 from .scanner import make_scanner, JSONDecodeError
 
 def _import_c_scanstring():
@@ -40,14 +40,14 @@ _CONSTANTS = {
 
 STRINGCHUNK = re.compile(r'(.*?)(["\\\x00-\x1f])', FLAGS)
 BACKSLASH = {
-    '"': u('"'), '\\': u('\u005c'), '/': u('/'),
-    'b': u('\b'), 'f': u('\f'), 'n': u('\n'), 'r': u('\r'), 't': u('\t'),
+    '"': u'"', '\\': u'\\', '/': u'/',
+    'b': u'\b', 'f': u'\f', 'n': u'\n', 'r': u'\r', 't': u'\t',
 }
 
 DEFAULT_ENCODING = "utf-8"
 
 def py_scanstring(s, end, encoding=None, strict=True,
-        _b=BACKSLASH, _m=STRINGCHUNK.match, _join=u('').join,
+        _b=BACKSLASH, _m=STRINGCHUNK.match, _join=u''.join,
         _PY3=PY3, _maxunicode=sys.maxunicode):
     """Scan the string s for a JSON string. End is the index of the
     character in s after the quote that started the JSON string.
@@ -71,8 +71,8 @@ def py_scanstring(s, end, encoding=None, strict=True,
         content, terminator = chunk.groups()
         # Content is contains zero or more unescaped string characters
         if content:
-            if not _PY3 and not isinstance(content, text_type):
-                content = text_type(content, encoding)
+            if not _PY3 and not isinstance(content, unicode):
+                content = unicode(content, encoding)
             _append(content)
         # Terminator is the end of string, a literal control character,
         # or a backslash denoting that an escape sequence follows
@@ -365,7 +365,7 @@ class JSONDecoder(object):
         instance containing a JSON document)
 
         """
-        if _PY3 and isinstance(s, binary_type):
+        if _PY3 and isinstance(s, bytes):
             s = s.decode(self.encoding)
         obj, end = self.raw_decode(s)
         end = _w(s, end).end()
@@ -388,7 +388,7 @@ class JSONDecoder(object):
             # Ensure that raw_decode bails on negative indexes, the regex
             # would otherwise mask this behavior. #98
             raise JSONDecodeError('Expecting value', s, idx)
-        if _PY3 and not isinstance(s, text_type):
+        if _PY3 and not isinstance(s, str):
             raise TypeError("Input string must be text, not bytes")
         # strip UTF-8 bom
         if len(s) > idx:

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -5,7 +5,7 @@ import re
 from operator import itemgetter
 # Do not import Decimal directly to avoid reload issues
 import decimal
-from .compat import u, unichr, binary_type, text_type, string_types, integer_types, PY3
+from .compat import unichr, binary_type, string_types, integer_types, PY3
 def _import_speedups():
     try:
         from . import _speedups
@@ -35,15 +35,15 @@ for i in range(0x20):
 
 FLOAT_REPR = repr
 
-def encode_basestring(s, _PY3=PY3, _q=u('"')):
+def encode_basestring(s, _PY3=PY3, _q=u'"'):
     """Return a JSON representation of a Python string
 
     """
     if _PY3:
-        if isinstance(s, binary_type):
+        if isinstance(s, bytes):
             s = s.decode('utf-8')
-        if type(s) is not text_type:
-            s = text_type.__str__(s)
+        if type(s) is not str:
+            s = str.__str__(s)
     else:
         if isinstance(s, str) and HAS_UTF8.search(s) is not None:
             s = s.decode('utf-8')
@@ -62,10 +62,10 @@ def py_encode_basestring_ascii(s, _PY3=PY3):
 
     """
     if _PY3:
-        if isinstance(s, binary_type):
+        if isinstance(s, bytes):
             s = s.decode('utf-8')
-        if type(s) is not text_type:
-            s = text_type.__str__(s)
+        if type(s) is not str:
+            s = str.__str__(s)
     else:
         if isinstance(s, str) and HAS_UTF8.search(s) is not None:
             s = s.decode('utf-8')
@@ -483,7 +483,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             else:
                 buf = separator
             if (isinstance(value, string_types) or
-                (_PY3 and isinstance(value, binary_type))):
+                (_PY3 and isinstance(value, bytes))):
                 yield buf + _encoder(value)
             elif isinstance(value, RawJSON):
                 yield buf + value.encoded_json
@@ -604,7 +604,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             yield _encoder(key)
             yield _key_separator
             if (isinstance(value, string_types) or
-                (_PY3 and isinstance(value, binary_type))):
+                (_PY3 and isinstance(value, bytes))):
                 yield _encoder(value)
             elif isinstance(value, RawJSON):
                 yield value.encoded_json
@@ -648,7 +648,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
 
     def _iterencode(o, _current_indent_level):
         if (isinstance(o, string_types) or
-            (_PY3 and isinstance(o, binary_type))):
+            (_PY3 and isinstance(o, bytes))):
             yield _encoder(o)
         elif isinstance(o, RawJSON):
             yield o.encoded_json

--- a/simplejson/tests/test_dump.py
+++ b/simplejson/tests/test_dump.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from simplejson.compat import StringIO, long_type, b, binary_type, text_type, PY3
+from simplejson.compat import StringIO, long_type, b, text_type, PY3
 import simplejson as json
 
 class MisbehavingTextSubtype(text_type):
@@ -7,7 +7,7 @@ class MisbehavingTextSubtype(text_type):
         return "FAIL!"
 
 def as_text_type(s):
-    if PY3 and isinstance(s, binary_type):
+    if PY3 and isinstance(s, bytes):
         return s.decode('ascii')
     return s
 

--- a/simplejson/tests/test_errors.py
+++ b/simplejson/tests/test_errors.py
@@ -2,7 +2,7 @@ import sys, pickle
 from unittest import TestCase
 
 import simplejson as json
-from simplejson.compat import u, b
+from simplejson.compat import text_type, b
 
 class TestErrors(TestCase):
     def test_string_keys_error(self):
@@ -41,7 +41,7 @@ class TestErrors(TestCase):
 
     def test_scan_error(self):
         err = None
-        for t in (u, b):
+        for t in (text_type, b):
             try:
                 json.loads(t('{"asdf": "'))
             except json.JSONDecodeError:

--- a/simplejson/tests/test_str_subclass.py
+++ b/simplejson/tests/test_str_subclass.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import simplejson
-from simplejson.compat import text_type, u
+from simplejson.compat import text_type
 
 # Tests for issue demonstrated in https://github.com/simplejson/simplejson/issues/144
 class WonkyTextSubclass(text_type):
@@ -10,7 +10,7 @@ class WonkyTextSubclass(text_type):
 
 class TestStrSubclass(TestCase):
     def test_dump_load(self):
-        for s in ['', '"hello"', 'text', u('\u005c')]:
+        for s in ['', '"hello"', 'text', u'\u005c']:
             self.assertEqual(
                 s,
                 simplejson.loads(simplejson.dumps(WonkyTextSubclass(s))))

--- a/simplejson/tests/test_unicode.py
+++ b/simplejson/tests/test_unicode.py
@@ -3,7 +3,7 @@ import codecs
 from unittest import TestCase
 
 import simplejson as json
-from simplejson.compat import unichr, text_type, b, u, BytesIO
+from simplejson.compat import unichr, text_type, b, BytesIO
 
 class TestUnicode(TestCase):
     def test_encoding1(self):
@@ -93,7 +93,7 @@ class TestUnicode(TestCase):
     def test_ensure_ascii_false_bytestring_encoding(self):
         # http://code.google.com/p/simplejson/issues/detail?id=48
         doc1 = {u'quux': b('Arr\xc3\xaat sur images')}
-        doc2 = {u'quux': u('Arr\xeat sur images')}
+        doc2 = {u'quux': u'Arr\xeat sur images'}
         doc_ascii = '{"quux": "Arr\\u00eat sur images"}'
         doc_unicode = u'{"quux": "Arr\xeat sur images"}'
         self.assertEqual(json.dumps(doc1), doc_ascii)


### PR DESCRIPTION
Since the minimal supported Python 3 version is 3.3, the `u()` helper no longer needed.