### PR TITLE
Allow to disable serializing bytes by default in Python 3.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -192,8 +192,16 @@ Basic Usage
    .. versionchanged:: 2.1.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.
 
-   *encoding* is the character encoding for str instances, default is
-   ``'utf-8'``.
+   If *encoding* is not ``None``, then all input :class:`bytes` objects in
+   Python 3 and 8-bit strings in Python 2 will be transformed
+   into unicode using that encoding prior to JSON-encoding.  The default is
+   ``'utf-8'``.  If *encoding* is ``None``, then all :class:`bytes` objects
+   will be passed to the *default* function in Python 3
+
+   .. versionchanged:: 3.15.0
+      ``encoding=None`` disables serializing :class:`bytes` by default in
+      Python 3.
+
 
    *default(obj)* is a function that should return a serializable version of
    *obj* or raise :exc:`TypeError`. The default simply raises :exc:`TypeError`.
@@ -656,9 +664,15 @@ Encoders and decoders
    that can't otherwise be serialized.  It should return a JSON encodable
    version of the object or raise a :exc:`TypeError`.
 
-   If *encoding* is not ``None``, then all input strings will be transformed
+   If *encoding* is not ``None``, then all input :class:`bytes` objects in
+   Python 3 and 8-bit strings in Python 2 will be transformed
    into unicode using that encoding prior to JSON-encoding.  The default is
-   ``'utf-8'``.
+   ``'utf-8'``.  If *encoding* is ``None``, then all :class:`bytes` objects
+   will be passed to the :meth:`default` method in Python 3
+
+   .. versionchanged:: 3.15.0
+      ``encoding=None`` disables serializing :class:`bytes` by default in
+      Python 3.
 
    If *namedtuple_as_object* is true (default: ``True``),
    objects with ``_asdict()`` methods will be encoded


### PR DESCRIPTION
If *encoding* is `None`, then bytes objects will be passed to the `default()` method instead of transforming into unicode.

Closes #213.