### PR TITLE
Support builds without cStringIO.

### DIFF
--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -5,8 +5,11 @@ if sys.version_info[0] < 3:
     PY3 = False
     def b(s):
         return s
-    import cStringIO as StringIO
-    StringIO = BytesIO = StringIO.StringIO
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
+    BytesIO = StringIO
     text_type = unicode
     binary_type = str
     string_types = (basestring,)
@@ -21,9 +24,7 @@ else:
         from imp import reload as reload_module
     def b(s):
         return bytes(s, 'latin1')
-    import io
-    StringIO = io.StringIO
-    BytesIO = io.BytesIO
+    from io import StringIO, BytesIO
     text_type = str
     binary_type = bytes
     string_types = (str,)

--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import unittest
-import doctest
 import sys
 import os
 
@@ -28,6 +27,13 @@ def additional_tests(suite=None):
     import simplejson.decoder
     if suite is None:
         suite = unittest.TestSuite()
+    try:
+        import doctest
+    except ImportError:
+        if sys.version_info < (2, 7):
+            # doctests in 2.6 depends on cStringIO
+            return suite
+        raise
     for mod in (simplejson, simplejson.encoder, simplejson.decoder):
         suite.addTest(doctest.DocTestSuite(mod))
     suite.addTest(doctest.DocFileSuite('../../index.rst'))


### PR DESCRIPTION
The `cStringIO` module is optional. Fall back to `StringIO` if it is not available.

The `docstrings` module in Python 2.5 and 2.6 unconditionally depends on `cStringIO`. Skip these tests if it is not available on these versions.