### PR TITLE
On Python 2, decode empty strings as str not unicode.

### DIFF
--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -76,6 +76,9 @@ static PyObject *JSON_Infinity = NULL;
 static PyObject *JSON_NegInfinity = NULL;
 static PyObject *JSON_NaN = NULL;
 static PyObject *JSON_EmptyUnicode = NULL;
+#if PY_MAJOR_VERSION < 3
+static PyObject *JSON_EmptyStr = NULL;
+#endif
 
 static PyTypeObject PyScannerType;
 static PyTypeObject PyEncoderType;
@@ -785,12 +788,7 @@ join_list_string(PyObject *lst)
     /* return ''.join(lst) */
     static PyObject *joinfn = NULL;
     if (joinfn == NULL) {
-        PyObject *ustr = PyString_FromStringAndSize(NULL, 0);
-        if (ustr == NULL)
-            return NULL;
-
-        joinfn = PyObject_GetAttrString(ustr, "join");
-        Py_DECREF(ustr);
+        joinfn = PyObject_GetAttrString(JSON_EmptyStr, "join");
         if (joinfn == NULL)
             return NULL;
     }
@@ -1026,7 +1024,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
         if (chunk != NULL)
             rval = chunk;
         else {
-            rval = JSON_EmptyUnicode;
+            rval = JSON_EmptyStr;
             Py_INCREF(rval);
         }
     }
@@ -3331,6 +3329,9 @@ init_constants(void)
 #if PY_MAJOR_VERSION >= 3
     JSON_EmptyUnicode = PyUnicode_New(0, 127);
 #else /* PY_MAJOR_VERSION >= 3 */
+    JSON_EmptyStr = PyString_FromString("");
+    if (JSON_EmptyStr == NULL)
+	return 0;
     JSON_EmptyUnicode = PyUnicode_FromUnicode(NULL, 0);
 #endif /* PY_MAJOR_VERSION >= 3 */
     if (JSON_EmptyUnicode == NULL)

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -3331,7 +3331,7 @@ init_constants(void)
 #else /* PY_MAJOR_VERSION >= 3 */
     JSON_EmptyStr = PyString_FromString("");
     if (JSON_EmptyStr == NULL)
-	return 0;
+        return 0;
     JSON_EmptyUnicode = PyUnicode_FromUnicode(NULL, 0);
 #endif /* PY_MAJOR_VERSION >= 3 */
     if (JSON_EmptyUnicode == NULL)

--- a/simplejson/tests/test_scanstring.py
+++ b/simplejson/tests/test_scanstring.py
@@ -22,6 +22,8 @@ class TestScanString(TestCase):
             return
         self._test_scanstring(simplejson.decoder.c_scanstring)
 
+        self.assertTrue(isinstance(simplejson.decoder.c_scanstring('""', 0)[0], str))
+
     def _test_scanstring(self, scanstring):
         if sys.maxunicode == 65535:
             self.assertEqual(


### PR DESCRIPTION
In general on Python 2, simplejson decodes ASCII strings as str, only promoting
to unicode when needed:
```
>>> simplejson.loads('["Spaetzle", "Spätzle"]')
['Spaetzle', u'Sp\xe4tzle']
```
Since 83a493db6a8b859ec7b10fa85365dd3fdf144c68, though, simplejson has always
decoded empty JSON strings as unicode:
```
>>> simplejson.loads('""')
u''
```
This PR restores the old behavior of decoding empty strings as str.