### PR TITLE
modified: Allowed to specify alternative string for `NaN/Infinity/-Infinity` .

### DIFF
--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -147,6 +147,9 @@ _default_encoder = JSONEncoder(
     for_json=False,
     ignore_nan=False,
     int_as_string_bitcount=None,
+    alternative_nan='NaN',
+    alternative_pos_inf='Infinity',
+    alternative_neg_inf='-Infinity',
 )
 
 def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
@@ -155,7 +158,8 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
          namedtuple_as_object=True, tuple_as_array=True,
          bigint_as_string=False, sort_keys=False, item_sort_key=None,
          for_json=False, ignore_nan=False, int_as_string_bitcount=None,
-         iterable_as_array=False, **kw):
+         iterable_as_array=False, alternative_nan='NaN',
+         alternative_pos_inf='Infinity', alternative_neg_inf='-Infinity', **kw):
     """Serialize ``obj`` as a JSON formatted stream to ``fp`` (a
     ``.write()``-supporting file-like object).
 
@@ -253,6 +257,8 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
         and not bigint_as_string and not sort_keys
         and not item_sort_key and not for_json
         and not ignore_nan and int_as_string_bitcount is None
+        and alternative_nan == 'NaN' and alternative_pos_inf == 'Infinity'
+        and alternative_neg_inf == '-Infinity'
         and not kw
     ):
         iterable = _default_encoder.iterencode(obj)
@@ -272,6 +278,9 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
             for_json=for_json,
             ignore_nan=ignore_nan,
             int_as_string_bitcount=int_as_string_bitcount,
+            alternative_nan=alternative_nan,
+            alternative_pos_inf=alternative_pos_inf,
+            alternative_neg_inf=alternative_neg_inf,
             **kw).iterencode(obj)
     # could accelerate with writelines in some versions of Python, at
     # a debuggability cost
@@ -285,7 +294,9 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
           namedtuple_as_object=True, tuple_as_array=True,
           bigint_as_string=False, sort_keys=False, item_sort_key=None,
           for_json=False, ignore_nan=False, int_as_string_bitcount=None,
-          iterable_as_array=False, **kw):
+          iterable_as_array=False, alternative_nan='NaN',
+          alternative_pos_inf='Infinity', alternative_neg_inf='-Infinity',
+          **kw):
     """Serialize ``obj`` to a JSON formatted ``str``.
 
     If ``skipkeys`` is false then ``dict`` keys that are not basic types
@@ -377,6 +388,8 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
         and not bigint_as_string and not sort_keys
         and not item_sort_key and not for_json
         and not ignore_nan and int_as_string_bitcount is None
+        and alternative_nan == 'NaN' and alternative_pos_inf == 'Infinity'
+        and alternative_neg_inf == '-Infinity'
         and not kw
     ):
         return _default_encoder.encode(obj)
@@ -396,6 +409,9 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,
         for_json=for_json,
         ignore_nan=ignore_nan,
         int_as_string_bitcount=int_as_string_bitcount,
+        alternative_nan=alternative_nan,
+        alternative_pos_inf=alternative_pos_inf,
+        alternative_neg_inf=alternative_neg_inf,
         **kw).encode(obj)
 
 

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -144,7 +144,9 @@ class JSONEncoder(object):
                  use_decimal=True, namedtuple_as_object=True,
                  tuple_as_array=True, bigint_as_string=False,
                  item_sort_key=None, for_json=False, ignore_nan=False,
-                 int_as_string_bitcount=None, iterable_as_array=False):
+                 int_as_string_bitcount=None, iterable_as_array=False,
+                 alternative_nan='NaN', alternative_pos_inf='Infinity',
+                 alternative_neg_inf='-Infinity'):
         """Constructor for JSONEncoder, with sensible defaults.
 
         If skipkeys is false, then it is a TypeError to attempt
@@ -240,6 +242,9 @@ class JSONEncoder(object):
         self.for_json = for_json
         self.ignore_nan = ignore_nan
         self.int_as_string_bitcount = int_as_string_bitcount
+        self.alternative_nan = alternative_nan
+        self.alternative_pos_inf = alternative_pos_inf
+        self.alternative_neg_inf = alternative_neg_inf
         if indent is not None and not isinstance(indent, string_types):
             indent = indent * ' '
         self.indent = indent
@@ -332,11 +337,11 @@ class JSONEncoder(object):
             # the internals.
 
             if o != o:
-                text = 'NaN'
+                text = self.alternative_nan
             elif o == _inf:
-                text = 'Infinity'
+                text = self.alternative_pos_inf
             elif o == _neginf:
-                text = '-Infinity'
+                text = self.alternative_neg_inf
             else:
                 if type(o) != float:
                     # See #118, do not trust custom str/repr


### PR DESCRIPTION
`cls` and/or `default` can not replace specify string from `nan/inf/-inf` .

this commit modified to allow to specify alternative string for `NaN/Infinity/-Infinity` .

sample
```python
import simplejson as json

print(json.dumps({'foo': 100}))
print(json.dumps({'foo': 'str'}))
print(json.dumps({'foo': None}))
print(json.dumps({'foo': True}))
print(json.dumps({'foo': False}))
print(json.dumps({'foo': float('nan')}))
print(json.dumps({'foo': float('inf')}))
print(json.dumps({'foo': float('-inf')}))
print(json.dumps({
    'foo': float('nan'),
    'bar': float('inf'),
    'baz': float('-inf'),
}))
print(json.dumps({
    'foo': float('nan'),
    'bar': float('inf'),
    'baz': float('-inf'),
}, alternative_nan='nan'))
print(json.dumps({
    'foo': float('nan'),
    'bar': float('inf'),
    'baz': float('-inf'),
}, alternative_pos_inf='posinf'))
print(json.dumps({
    'foo': float('nan'),
    'bar': float('inf'),
    'baz': float('-inf'),
}, alternative_neg_inf='neginf'))
print(json.dumps(
    {
        'foo': float('nan'),
        'bar': float('inf'),
        'baz': float('-inf'),
    },
    alternative_nan='nan',
    alternative_pos_inf='posinf',
    alternative_neg_inf='neginf'
))
```

result
```
{"foo": 100}
{"foo": "str"}
{"foo": null}
{"foo": true}
{"foo": false}
{"foo": NaN}
{"foo": Infinity}
{"foo": -Infinity}
{"foo": NaN, "bar": Infinity, "baz": -Infinity}
{"foo": nan, "bar": Infinity, "baz": -Infinity}
{"foo": NaN, "bar": posinf, "baz": -Infinity}
{"foo": NaN, "bar": Infinity, "baz": neginf}
{"foo": nan, "bar": posinf, "baz": neginf}
```
