### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,40 +7,31 @@ matrix:
   include:
   - os: linux
     dist: trusty
-    sudo: false
     python: '2.6'
   - os: linux
     dist: trusty
-    sudo: false
     python: '2.7'
   - os: linux
     dist: trusty
-    sudo: false
     python: '3.3'
   - os: linux
     dist: trusty
-    sudo: false
     python: '3.4'
   - os: linux
     dist: trusty
-    sudo: false
     python: '3.5'
   - os: linux
     dist: trusty
-    sudo: false
     python: '3.6'
   - os: linux
     dist: xenial
-    sudo: required
     services:
       - docker
     python: '3.7'
     env: BUILD_SDIST=true
   - os: linux
-    sudo: false
     python: pypy
   - os: linux
-    sudo: false
     python: pypy3
   - os: osx
     language: objective-c


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"