### PR TITLE
Travis CI: Simplify by upgrading to dist: xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,17 @@ cache:
   directories:
   - "$HOME/.cache/pip"
   - "$HOME/.pyenv"
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
 matrix:
   include:
-  - python: '2.6'
+  - python: 2.6
     dist: trusty
-  - python: '3.3'
+  - python: 2.7
+  - python: 3.3
     dist: trusty
+  - python: 3.4
+  - python: 3.5
+  - python: 3.6
+  - python: 3.7
   - python: pypy
     dist: trusty
   - python: pypy3
@@ -24,13 +23,16 @@ matrix:
     services:
       - docker
     env: BUILD_SDIST=true
-  - os: osx
+  - name: Python 2.7.12 on macOS
+    os: osx
     language: objective-c
     env: PYENV_VERSION=2.7.12
-  - os: osx
+  - name: Python 3.5.5 on macOS
+    os: osx
     language: objective-c
     env: PYENV_VERSION=3.5.5
-  - os: osx
+  - name: Python 3.6.5 on macOS
+    os: osx
     language: objective-c
     env: PYENV_VERSION=3.6.5
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ cache:
   - "$HOME/.cache/pip"
   - "$HOME/.pyenv"
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -16,6 +14,10 @@ python:
   - pypy3
 matrix:
   include:
+  - python: '2.6'
+    dist: trusty
+  - python: '3.3'
+    dist: trusty
   - python: '3.7'
     services:
       - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,17 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - pypy
-  - pypy3
 matrix:
   include:
   - python: '2.6'
     dist: trusty
   - python: '3.3'
     dist: trusty
-  - python: '3.7'
+  - python: pypy
+    dist: trusty
+  - python: pypy3
+    dist: trusty
+  - python: 3.7
     services:
       - docker
     env: BUILD_SDIST=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,25 @@
 language: python
+dist: xenial  # required for Python >= 3.7
 cache:
   directories:
   - "$HOME/.cache/pip"
   - "$HOME/.pyenv"
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
+  - pypy
+  - pypy3
 matrix:
   include:
-  - os: linux
-    dist: trusty
-    python: '2.6'
-  - os: linux
-    dist: trusty
-    python: '2.7'
-  - os: linux
-    dist: trusty
-    python: '3.3'
-  - os: linux
-    dist: trusty
-    python: '3.4'
-  - os: linux
-    dist: trusty
-    python: '3.5'
-  - os: linux
-    dist: trusty
-    python: '3.6'
-  - os: linux
-    dist: xenial
+  - python: '3.7'
     services:
       - docker
-    python: '3.7'
     env: BUILD_SDIST=true
-  - os: linux
-    python: pypy
-  - os: linux
-    python: pypy3
   - os: osx
     language: objective-c
     env: PYENV_VERSION=2.7.12


### PR DESCRIPTION
__Trusty__ reaches its [end-of-life this month](https://wiki.ubuntu.com/Releases) so we should stop hardcoding it.