### PR TITLE
Added arm64 support in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,25 @@ matrix:
   - python: 3.4
   - python: 3.5
   - python: 3.6
+  - python: 3.6
+    arch: arm64
   - python: 3.7
+  - python: 3.7
+    arch: arm64
   - python: 3.8
+  - python: 3.8
+    arch: arm64
   - python: pypy
   - python: pypy3
   - python: 3.8
     services:
     - docker
     env: BUILD_SDIST=true
+  - python: 3.8
+    arch: arm64
+    services:
+    - docker
+    env: BUILD_WHEEL=true
   - name: Python 2.7.17 on macOS
     os: osx
     language: objective-c

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -23,5 +23,5 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 fi
 
 if [[ $BUILD_WHEEL == 'true' ]]; then
-    pip install wheel cibuildwheel==0.9.4
+    pip install wheel cibuildwheel==1.5.2
 fi


### PR DESCRIPTION
Updated travis.yml file to add ARM64 jobs in Travis-CI. Added support for python version 3.6, 3,7 and 3.8 for ARM64 jobs.
Updated cibuildwheel version as the latest version have support for manylinux2014. Resolves #263 