### PR TITLE
Fix the C extension module to harden is_namedtuple.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+* Fix the C extension module to harden is_namedtuple against looks-a-likes such
+  as Mocks. Also prevent dict encoding from causing an unraised SystemError when
+  encountering a non-Dict. Noticed by running user tests against a CPython
+  interpreter with C asserts enabled (COPTS += -UNDEBUG).
+
 Version 3.17.3 released 2021-07-09
 
 * Replaced Travis-CI and AppVeyor with Github Actions,

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2856,6 +2856,11 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             newobj = PyObject_CallMethod(obj, "_asdict", NULL);
             if (newobj != NULL) {
                 if (!PyDict_Check(newobj)) {
+                    PyErr_Format(
+                        PyExc_TypeError,
+                        "_asdict() must return a dict, not %.80s",
+                        Py_TYPE(newobj)->tp_name
+                    );
                     Py_DECREF(newobj);
                     return -1;
                 }

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -386,6 +386,9 @@ static int
 _is_namedtuple(PyObject *obj)
 {
     int rval = 0;
+    if (!PyTuple_Check(obj)) {
+        return 0;
+    }
     PyObject *_asdict = PyObject_GetAttrString(obj, "_asdict");
     if (_asdict == NULL) {
         PyErr_Clear();
@@ -2953,6 +2956,9 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
     PyObject *encoded = NULL;
     Py_ssize_t idx;
 
+    if (!PyDict_Check(dct)) {
+        return -1;
+    }
     if (open_dict == NULL || close_dict == NULL || empty_dict == NULL) {
         open_dict = JSON_InternFromString("{");
         close_dict = JSON_InternFromString("}");

--- a/simplejson/tests/test_namedtuple.py
+++ b/simplejson/tests/test_namedtuple.py
@@ -145,5 +145,5 @@ class TestNamedTuple(unittest.TestCase):
         # potential for internal data corruption.  Getting it to crash in
         # a debug build is not always easy either as it requires an
         # assert(!PyErr_Occurred()) that could fire later on.
-        self.assertRaises(TypeError):
+        with self.assertRaises(TypeError):
             json.dumps({23: fake}, namedtuple_as_object=True, for_json=False)

--- a/simplejson/tests/test_namedtuple.py
+++ b/simplejson/tests/test_namedtuple.py
@@ -4,6 +4,11 @@ import simplejson as json
 from simplejson.compat import StringIO
 
 try:
+    from unittest import mock
+except ImportError:
+    mock = None
+
+try:
     from collections import namedtuple
 except ImportError:
     class Value(tuple):
@@ -120,3 +125,25 @@ class TestNamedTuple(unittest.TestCase):
             self.assertEqual(
                 json.dumps(f({})),
                 json.dumps(f(DeadDict()), namedtuple_as_object=True))
+
+    def test_asdict_does_not_return_dict(self):
+        if not mock:
+            if hasattr(unittest, "SkipTest"):
+                raise unittest.SkipTest("unittest.mock required")
+            else:
+                print("unittest.mock not available")
+                return
+        fake = mock.Mock()
+        self.assertTrue(hasattr(fake, '_asdict'))
+        self.assertTrue(callable(fake._asdict))
+        self.assertFalse(isinstance(fake._asdict(), dict))
+        # https://github.com/simplejson/simplejson/pull/284
+        # when running under a debug build of CPython (COPTS=-UNDEBUG)
+        # a C assertion could fire due to an unchecked error of an PyDict
+        # API call on a non-dict internally in _speedups.c.  Without a debug
+        # build of CPython this test likely passes either way despite the
+        # potential for internal data corruption.  Getting it to crash in
+        # a debug build is not always easy either as it requires an
+        # assert(!PyErr_Occurred()) that could fire later on.
+        self.assertRaises(TypeError):
+            json.dumps({23: fake}, namedtuple_as_object=True, for_json=False)


### PR DESCRIPTION
Protects against looks-a-likes such as Mocks. Also prevent dict encoding
from causing an unraised SystemError when encountering a non-Dict.
Noticed by running application tests against a CPython interpreter with C
asserts enabled (COPTS += -UNDEBUG) which crashed.

I didn't actually dive into figure out what data structure the code managed to
try to serialize that managed to get a MagicMock or StubMock instance
into `encoder_listencode_obj` where it wound up passing `_is_namedtuple`
leading to the assert-crash triggering problems this PR fixes.

Contributed-By: Gregory P. Smith [Google]