### PR TITLE
Check the unicode code point range before unichr() is called

### DIFF
--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -109,6 +109,8 @@ def py_scanstring(s, end, encoding=None, strict=True,
                 uni = int(esc, 16)
             except ValueError:
                 raise JSONDecodeError(msg, s, end - 1)
+            if uni < 0 or uni > _maxunicode:
+                raise JSONDecodeError(msg, s, end - 1)
             end += 5
             # Check for surrogate pair on UCS-4 systems
             # Note that this will join high/low surrogate pairs

--- a/simplejson/tests/test_scanstring.py
+++ b/simplejson/tests/test_scanstring.py
@@ -132,6 +132,8 @@ class TestScanString(TestCase):
             self.assertRaises(ValueError,
                               scanstring, '\\ud834\\x0123"', 0, None, True)
 
+        self.assertRaises(json.JSONDecodeError, scanstring, "\\u-123", 0, None, True)
+
     def test_issue3623(self):
         self.assertRaises(ValueError, json.decoder.scanstring, "xxx", 1,
                           "xxx")


### PR DESCRIPTION
Fixes #297 
