### PR TITLE
Clear `i` var from loop not to leak into module namespace

### DIFF
--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -32,6 +32,7 @@ ESCAPE_DCT = {
 for i in range(0x20):
     #ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
     ESCAPE_DCT.setdefault(chr(i), '\\u%04x' % (i,))
+del i
 
 FLOAT_REPR = repr
 


### PR DESCRIPTION
Otherwise it is accesible to users to be imported / used.