### PR TITLE
Disable speedups on GraalPy same as on PyPy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,6 +11,25 @@ on: [push, pull_request]
 #       - published
 
 jobs:
+  test_pure_python:
+    name: Tests without speedup on ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - 'ubuntu-latest'
+        python:
+          - 3.13
+          - pypy-3.11
+          - graalpy-25.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -m simplejson.tests._cibw_runner .
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
+IS_GRAALPY = getattr(getattr(sys, "implementation", None), "name", None) == "graalpy"
 VERSION = '3.20.1'
 DESCRIPTION = "Simple, fast, extensible JSON encoder/decoder for Python"
 
@@ -124,7 +125,7 @@ def run_setup(with_binary):
         **kw)
 
 
-DISABLE_SPEEDUPS = IS_PYPY or os.environ.get('DISABLE_SPEEDUPS') == '1'
+DISABLE_SPEEDUPS = IS_PYPY or IS_GRAALPY or os.environ.get('DISABLE_SPEEDUPS') == '1'
 CIBUILDWHEEL = os.environ.get('CIBUILDWHEEL') == '1'
 REQUIRE_SPEEDUPS = CIBUILDWHEEL or os.environ.get('REQUIRE_SPEEDUPS') == '1'
 try:

--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -18,7 +18,7 @@ class TestMissingSpeedups(unittest.TestCase):
     def runTest(self):
         if hasattr(sys, "pypy_translation_info"):
             "PyPy doesn't need speedups! :)"
-        elif getattr(getattr(sys, "implementation", None), "name", None) == "graalpy"
+        elif getattr(getattr(sys, "implementation", None), "name", None) == "graalpy":
             "GraalPy doesn't need speedups! :)"
         elif hasattr(self, "skipTest"):
             self.skipTest("_speedups.so is missing!")

--- a/simplejson/tests/__init__.py
+++ b/simplejson/tests/__init__.py
@@ -18,6 +18,8 @@ class TestMissingSpeedups(unittest.TestCase):
     def runTest(self):
         if hasattr(sys, "pypy_translation_info"):
             "PyPy doesn't need speedups! :)"
+        elif getattr(getattr(sys, "implementation", None), "name", None) == "graalpy"
+            "GraalPy doesn't need speedups! :)"
         elif hasattr(self, "skipTest"):
             self.skipTest("_speedups.so is missing!")
 


### PR DESCRIPTION
With this change when building from source GraalPy does not receive the native extension (which does not help much, same as on PyPy)