### PR TITLE
Initial free threading port

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,13 +31,13 @@ jobs:
       - run: python -m simplejson.tests._cibw_runner .
 
   test_free_threading:
-    name: Tests with free-threading on Python 3.13t
+    name: Tests with free-threading on Python 3.14t
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13t'
+          python-version: '3.14t'
       - name: Build extension with free-threading support
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -30,6 +30,21 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: python -m simplejson.tests._cibw_runner .
 
+  test_free_threading:
+    name: Tests with free-threading on Python 3.13t
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13t'
+      - name: Build extension with free-threading support
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          REQUIRE_SPEEDUPS=1 python setup.py build_ext -i
+      - name: Run tests
+        run: python -m simplejson.tests._cibw_runner .
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -421,9 +421,7 @@ static int
 flush_accumulator(speedups_modulestate *st, JSON_Accu *acc)
 {
     Py_ssize_t nsmall;
-    Py_BEGIN_CRITICAL_SECTION(acc->small_strings);
     nsmall = PyList_GET_SIZE(acc->small_strings);
-    Py_END_CRITICAL_SECTION();
     if (nsmall) {
         int ret;
         PyObject *joined;
@@ -462,9 +460,7 @@ JSON_Accu_Accumulate(speedups_modulestate *st, JSON_Accu *acc, PyObject *unicode
 
     if (PyList_Append(acc->small_strings, unicode))
         return -1;
-    Py_BEGIN_CRITICAL_SECTION(acc->small_strings);
     nsmall = PyList_GET_SIZE(acc->small_strings);
-    Py_END_CRITICAL_SECTION();
     /* Each item in a list of unicode objects has an overhead (in 64-bit
      * builds) of:
      *   - 8 bytes for the list slot
@@ -1888,11 +1884,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
 
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || str[idx] != ']') {
-        Py_ssize_t rval_size;
-        Py_BEGIN_CRITICAL_SECTION(rval);
-        rval_size = PyList_GET_SIZE(rval);
-        Py_END_CRITICAL_SECTION();
-        if (rval_size) {
+        if (PyList_GET_SIZE(rval)) {
             raise_errmsg(st, ERR_ARRAY_DELIMITER, pystr, idx);
         } else {
             raise_errmsg(st, ERR_ARRAY_VALUE_FIRST, pystr, idx);
@@ -1974,11 +1966,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
 
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
-        Py_ssize_t rval_size;
-        Py_BEGIN_CRITICAL_SECTION(rval);
-        rval_size = PyList_GET_SIZE(rval);
-        Py_END_CRITICAL_SECTION();
-        if (rval_size) {
+        if (PyList_GET_SIZE(rval)) {
             raise_errmsg(st, ERR_ARRAY_DELIMITER, pystr, idx);
         } else {
             raise_errmsg(st, ERR_ARRAY_VALUE_FIRST, pystr, idx);

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -113,14 +113,6 @@ compat_PyType_GetModuleState(PyTypeObject *type)
 #define PyType_GetModuleState compat_PyType_GetModuleState
 #endif
 
-/* Compatibility shims for free-threading support */
-#if PY_VERSION_HEX < 0x030D0000
-#define Py_BEGIN_CRITICAL_SECTION(op) {
-#define Py_END_CRITICAL_SECTION() }
-#define Py_BEGIN_CRITICAL_SECTION2(op1, op2) {
-#define Py_END_CRITICAL_SECTION2() }
-#endif
-
 #if PY_VERSION_HEX < 0x030D0000
 /* Compatibility wrapper for PyDict_GetItemRef for Python < 3.13 */
 static inline int _compat_PyDict_GetItemRef(PyObject *mp, PyObject *key, PyObject **result)

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1470,9 +1470,7 @@ scanner_dealloc(PyObject *self)
 static int
 scanner_traverse(PyObject *self, visitproc visit, void *arg)
 {
-    PyScannerObject *s;
-    assert(PyScanner_Check(self));
-    s = (PyScannerObject *)self;
+    PyScannerObject *s = (PyScannerObject *)self;
     Py_VISIT(s->encoding);
     Py_VISIT(s->strict_bool);
     Py_VISIT(s->object_hook);
@@ -1487,9 +1485,7 @@ scanner_traverse(PyObject *self, visitproc visit, void *arg)
 static int
 scanner_clear(PyObject *self)
 {
-    PyScannerObject *s;
-    assert(PyScanner_Check(self));
-    s = (PyScannerObject *)self;
+    PyScannerObject *s = (PyScannerObject *)self;
     Py_CLEAR(s->encoding);
     Py_CLEAR(s->strict_bool);
     Py_CLEAR(s->object_hook);
@@ -3419,9 +3415,7 @@ encoder_dealloc(PyObject *self)
 static int
 encoder_traverse(PyObject *self, visitproc visit, void *arg)
 {
-    PyEncoderObject *s;
-    assert(PyEncoder_Check(self));
-    s = (PyEncoderObject *)self;
+    PyEncoderObject *s = (PyEncoderObject *)self;
     Py_VISIT(s->markers);
     Py_VISIT(s->defaultfn);
     Py_VISIT(s->encoder);
@@ -3443,9 +3437,7 @@ static int
 encoder_clear(PyObject *self)
 {
     /* Deallocate Encoder */
-    PyEncoderObject *s;
-    assert(PyEncoder_Check(self));
-    s = (PyEncoderObject *)self;
+    PyEncoderObject *s = (PyEncoderObject *)self;
     Py_CLEAR(s->markers);
     Py_CLEAR(s->defaultfn);
     Py_CLEAR(s->encoder);

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -146,10 +146,6 @@ static inline int _compat_PyDict_GetItemRef(PyObject *mp, PyObject *key, PyObjec
 #define PyDict_GetItemRef _compat_PyDict_GetItemRef
 #endif
 
-#if PY_VERSION_HEX >= 0x030D0000
-#include "critical_section.h"
-#endif
-
 #ifndef Py_BEGIN_CRITICAL_SECTION
 #define Py_BEGIN_CRITICAL_SECTION(op) ((void)(op))
 #define Py_END_CRITICAL_SECTION() ((void)0)
@@ -168,20 +164,10 @@ static inline int _compat_PyDict_GetItemRef(PyObject *mp, PyObject *key, PyObjec
 
 #define DEFAULT_ENCODING "utf-8"
 
-static inline speedups_modulestate *
-module_state_from_type(PyTypeObject *type)
-{
-    return (speedups_modulestate *)PyType_GetModuleState(type);
-}
-
 static inline PyTypeObject *
 scanner_type_from_object(PyObject *op)
 {
-    speedups_modulestate *st = module_state_from_type(Py_TYPE(op));
-#if PY_VERSION_HEX < 0x03090000
-    if (st == NULL)
-        st = global_module_state;
-#endif
+    speedups_modulestate *st = (speedups_modulestate *)PyType_GetModuleState(Py_TYPE(op));
     if (st == NULL)
         return NULL;
     return st->ScannerType;
@@ -190,11 +176,7 @@ scanner_type_from_object(PyObject *op)
 static inline PyTypeObject *
 encoder_type_from_object(PyObject *op)
 {
-    speedups_modulestate *st = module_state_from_type(Py_TYPE(op));
-#if PY_VERSION_HEX < 0x03090000
-    if (st == NULL)
-        st = global_module_state;
-#endif
+    speedups_modulestate *st = (speedups_modulestate *)PyType_GetModuleState(Py_TYPE(op));
     if (st == NULL)
         return NULL;
     return st->EncoderType;
@@ -825,7 +807,7 @@ encoder_stringify_key(speedups_modulestate *st, PyEncoderObject *s, PyObject *ke
 static PyObject *
 encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
 {
-    speedups_modulestate *st = module_state_from_type(Py_TYPE(s));
+    speedups_modulestate *st = (speedups_modulestate *)PyType_GetModuleState(Py_TYPE(s));
     PyObject *items = NULL;
     PyObject *lst = NULL;
     PyObject *kstr = NULL;


### PR DESCRIPTION
[Triggered by this tweet](https://x.com/etrepum/status/1980144816664252758) I was really curious if Claude can implement free threading support on my bike ride to the office.  The answer seems to be: yes.

This now is a much more complex implementation than the initial commit which only removed the GIL.  This implementation now is makes it both sub-interpreter and free-threading ready.  Given that the code also still supports Python 2.x there are now quite a few paths to take care of.

Important notes: the standard library's JSON module uses a macro called `Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST` and `PySequence_Fast`.  The former uses private APIs which are not exposed and as such we have no option to do that.  The new code special cases lists and tuples and then falls back to the iterator interface.  I'm generally not sure if that is the right approach but this is what some back and forth with codex and claude suggested as the optimal solutions given the constraints.

I'm actually not entirely convinced because I did not run benchmarks.

Unfortunately this change overall drives up the complexity significantly given the many versions that this code needs to support.  For instance in Python 2 I don't think there is a way to avoid the static types so the code also needs to support that.

The code as it is produced right now is ~50% Claude, ~40% Codex and ~10% manual edits and has been going through multiple iterations of Codex based reviews.  I have manually reviewed it a few times now but if you think that approach makes any sense, I would probably make a proper manual pass over still.