### PR TITLE
Fix SetuptoolsDeprecationWarning for license classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ PYTHON_REQUIRES = '>=2.5, !=3.0.*, !=3.1.*, !=3.2.*'
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License',
-    'License :: OSI Approved :: Academic Free License (AFL)',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.5',
@@ -119,7 +117,7 @@ def run_setup(with_binary):
         author="Bob Ippolito",
         author_email="bob@redivi.com",
         url="https://github.com/simplejson/simplejson",
-        license="MIT License",
+        license="MIT OR AFL-2.1",
         packages=['simplejson', 'simplejson.tests'],
         platforms=['any'],
         **kw)


### PR DESCRIPTION
Fixes #338

This PR resolves the `SetuptoolsDeprecationWarning` about deprecated license classifiers by:

- Removing the deprecated `License :: OSI Approved :: MIT License` and `License :: OSI Approved :: Academic Free License (AFL)` classifiers
- Updating the `license` field to use the SPDX expression `MIT OR AFL-2.1` as recommended by [PEP 639](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)

The dual-license nature is preserved through the SPDX OR operator, matching what's documented in LICENSE.txt.

**Testing:**
Built the package locally with Python 3.13 - no more deprecation warnings during the build process.