### PR TITLE
Add per-object critical sections to scanner and encoder (free-threading safety)

### DIFF
--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -73,6 +73,7 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
 #define UNUSED
 #endif
 
+
 #define DEFAULT_ENCODING "utf-8"
 
 #define PyScanner_Check(op) PyObject_TypeCheck(op, &PyScannerType)
@@ -2346,7 +2347,7 @@ scanner_call(PyObject *self, PyObject *args, PyObject *kwds)
 {
     /* Python callable interface to scan_once_{str,unicode} */
     PyObject *pystr;
-    PyObject *rval;
+    PyObject *rval = NULL;
     Py_ssize_t idx;
     Py_ssize_t next_idx = -1;
     static char *kwlist[] = {"string", "idx", NULL};
@@ -2359,20 +2360,31 @@ scanner_call(PyObject *self, PyObject *args, PyObject *kwds)
     if (PyUnicode_Check(pystr)) {
         if (PyUnicode_READY(pystr))
             return NULL;
-        rval = scan_once_unicode(s, pystr, idx, &next_idx);
     }
 #if PY_MAJOR_VERSION < 3
-    else if (PyString_Check(pystr)) {
-        rval = scan_once_str(s, pystr, idx, &next_idx);
-    }
-#endif /* PY_MAJOR_VERSION < 3 */
+    else if (!PyString_Check(pystr)) {
+#else
     else {
+#endif
         PyErr_Format(PyExc_TypeError,
                  "first argument must be a string, not %.80s",
                  Py_TYPE(pystr)->tp_name);
         return NULL;
     }
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+
+    if (PyUnicode_Check(pystr)) {
+        rval = scan_once_unicode(s, pystr, idx, &next_idx);
+    }
+#if PY_MAJOR_VERSION < 3
+    else {
+        rval = scan_once_str(s, pystr, idx, &next_idx);
+    }
+#endif /* PY_MAJOR_VERSION < 3 */
     PyDict_Clear(s->memo);
+
+    Py_END_CRITICAL_SECTION();
     return _build_rval_index_tuple(rval, next_idx);
 }
 
@@ -2693,6 +2705,7 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     Py_ssize_t indent_level;
     PyEncoderObject *s;
     JSON_Accu rval;
+    int encode_rv;
     assert(PyEncoder_Check(self));
     s = (PyEncoderObject *)self;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&:_iterencode", kwlist,
@@ -2700,7 +2713,10 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     if (JSON_Accu_Init(&rval))
         return NULL;
-    if (encoder_listencode_obj(s, &rval, obj, indent_level)) {
+    Py_BEGIN_CRITICAL_SECTION(self);
+    encode_rv = encoder_listencode_obj(s, &rval, obj, indent_level);
+    Py_END_CRITICAL_SECTION();
+    if (encode_rv) {
         JSON_Accu_Destroy(&rval);
         return NULL;
     }

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -73,6 +73,13 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
 #define UNUSED
 #endif
 
+/* Py_BEGIN_CRITICAL_SECTION was added in Python 3.13.
+   On older versions, define as no-ops. */
+#if PY_VERSION_HEX < 0x030d0000
+#define Py_BEGIN_CRITICAL_SECTION(op)
+#define Py_END_CRITICAL_SECTION()
+#endif
+
 
 #define DEFAULT_ENCODING "utf-8"
 


### PR DESCRIPTION
Part of #362.

## Summary

Add `Py_BEGIN_CRITICAL_SECTION` / `Py_END_CRITICAL_SECTION` to `scanner_call` and
`encoder_call`. This serializes concurrent calls to the same scanner or encoder
instance, protecting per-instance mutable state:

- **Scanner**: `s->memo` dict — read via `PyDict_GetItem`, written via `PyDict_SetItem`,
  cleared via `PyDict_Clear` after each scan. Without locking, concurrent scans on a
  shared scanner race on the memo dict.
- **Encoder**: `s->markers` dict (circular reference tracking via `PyDict_Contains` /
  `PyDict_SetItem` / `PyDict_DelItem`) and `s->key_memo` dict (key string cache via
  `PyDict_GetItem` / `PyDict_SetItem`). Without locking, concurrent encodes on a shared
  encoder race on both dicts.

The critical sections are no-ops on non-free-threaded builds — `Py_BEGIN_CRITICAL_SECTION`
expands to `{` and `Py_END_CRITICAL_SECTION` to `}` on GIL-enabled Python. For Python
< 3.13 where the macros don't exist, we provide empty compat defines.

## Note on usage patterns

The common `simplejson.dumps()` / `simplejson.loads()` pattern creates fresh encoder/scanner
instances per call, so there is no shared state to protect. These critical sections guard
against the less-common pattern of sharing a `JSONEncoder` or scanner across threads
(e.g., `encoder = simplejson.JSONEncoder(); pool.map(encoder.encode, items)`).

## Test plan

- [x] `python -m pytest simplejson/tests/ -x -q` — 147 tests pass
- [x] Compiles cleanly on Python 3.13 (GIL-enabled build with real macros)
- [x] Compat defines for Python < 3.13

Found using [ft-review-toolkit](https://github.com/devdanzin/ft-review-toolkit).

<sub>This PR was drafted by Claude Code and reviewed by a human.</sub>