### PR TITLE
Fix free-threading (3.14t) crashes: heap types, unified per-module state, templated parser, new CI coverage

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -60,6 +60,63 @@ jobs:
       - name: Run tests with GIL disabled
         run: PYTHON_GIL=0 python -m simplejson.tests._cibw_runner .
 
+  test_debug_build:
+    name: Tests on Python 3.14 debug build
+    runs-on: ubuntu-latest
+    env:
+      # Pin the Python version so the cache key is stable. Bump when
+      # we want to pick up a new 3.14.x release.
+      PYTHON_VERSION: '3.14.0'
+      PYTHON_PREFIX: /opt/python-debug
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Python debug build
+        id: cache-python
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PYTHON_PREFIX }}
+          key: python-${{ env.PYTHON_VERSION }}-debug-${{ runner.os }}-v1
+
+      - name: Build Python ${{ env.PYTHON_VERSION }} with --with-pydebug
+        if: steps.cache-python.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libssl-dev zlib1g-dev libbz2-dev \
+            libreadline-dev libsqlite3-dev libffi-dev liblzma-dev
+          curl -fsSL -o Python.tar.xz \
+            "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
+          tar xf Python.tar.xz
+          cd Python-${PYTHON_VERSION}
+          ./configure --with-pydebug --disable-test-modules \
+            --prefix="${PYTHON_PREFIX}" --with-ensurepip=install
+          make -j "$(nproc)"
+          sudo make install
+          sudo chown -R "$(id -u):$(id -g)" "${PYTHON_PREFIX}"
+
+      - name: Add debug Python to PATH
+        run: echo "${PYTHON_PREFIX}/bin" >> "$GITHUB_PATH"
+
+      - name: Verify debug build
+        run: |
+          python3 -c "
+          import sys
+          assert hasattr(sys, 'gettotalrefcount'), (
+              'not a debug build (sys.gettotalrefcount missing)')
+          print('OK:', sys.version)
+          "
+
+      - name: Build extension with strict warnings (-Werror)
+        env:
+          CFLAGS: "-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type"
+        run: |
+          python3 -m pip install --upgrade setuptools wheel
+          REQUIRE_SPEEDUPS=1 python3 setup.py build_ext -i
+
+      - name: Run tests (TestRefcountLeaks auto-enabled on debug build)
+        run: python3 -m simplejson.tests._cibw_runner .
+
   build_wheels:
     name: Build wheels (${{ matrix.os }}, ${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
@@ -151,7 +208,7 @@ jobs:
   # Aggregate gate jobs to match branch protection rule names
   gate_ubuntu:
     name: Build wheels on ubuntu-latest
-    needs: [build_wheels, test_pure_python, test_free_threading]
+    needs: [build_wheels, test_pure_python, test_free_threading, test_debug_build]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All ubuntu-latest checks passed"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,21 +25,47 @@ jobs:
           - graalpy-25.0
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python }}
       - run: python -m simplejson.tests._cibw_runner .
 
+  test_free_threading:
+    name: Tests with free-threading on Python 3.14t
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5.6.0.6.0
+        with:
+          python-version: '3.14t'
+      - name: Build extension with free-threading support
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          REQUIRE_SPEEDUPS=1 python setup.py build_ext -i
+      - name: Verify GIL-free import (no RuntimeWarning)
+        run: PYTHON_GIL=0 python -W error::RuntimeWarning -c "import simplejson._speedups"
+      - name: Run tests
+        run: python -m simplejson.tests._cibw_runner .
+      - name: Run tests with GIL disabled
+        run: PYTHON_GIL=0 python -m simplejson.tests._cibw_runner .
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels (${{ matrix.os }}, ${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - 'ubuntu-latest'
-        - 'windows-latest'
-        - 'macos-latest'
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: ubuntu-latest
+            arch: ppc64le
+          - os: windows-latest
+            arch: auto
+          - os: macos-latest
+            arch: "x86_64 universal2 arm64"
 
     steps:
       - uses: actions/checkout@v4
@@ -51,29 +77,27 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"
-          CIBW_SKIP: "pp*"
-          CIBW_ARCHS_WINDOWS: "auto"
-          CIBW_ARCHS_LINUX: "auto aarch64 ppc64le"
-          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ENABLE: "cpython-freethreading"
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - name: Build Python 2.7 wheels
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.arch != 'ppc64le'
         uses: pypa/cibuildwheel@v1.12.0
         env:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_BUILD: "cp27-*"
           CIBW_SKIP: "pp*"
-          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -82,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         name: Install Python
         with:
           python-version: '3.14'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,7 +66,7 @@ jobs:
     env:
       # Pin the Python version so the cache key is stable. Bump when
       # we want to pick up a new 3.14.x release.
-      PYTHON_VERSION: '3.14.0'
+      PYTHON_VERSION: '3.14.4'
       PYTHON_PREFIX: /opt/python-debug
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
       - name: Install Python 3.14.4 debug build via python-build-standalone
         run: |
           uv python install cpython-3.14.4+debug

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
           - pypy-3.11
           - graalpy-25.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
@@ -34,7 +34,7 @@ jobs:
     name: Tests with free-threading on Python 3.14t
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14t'
@@ -69,11 +69,11 @@ jobs:
       PYTHON_VERSION: '3.14.4'
       PYTHON_PREFIX: /opt/python-debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache Python debug build
         id: cache-python
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.PYTHON_PREFIX }}
           key: python-${{ env.PYTHON_VERSION }}-debug-${{ runner.os }}-v1
@@ -107,9 +107,7 @@ jobs:
           print('OK:', sys.version)
           "
 
-      - name: Build extension with strict warnings (-Werror)
-        env:
-          CFLAGS: "-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type"
+      - name: Build extension
         run: |
           python3 -m pip install --upgrade setuptools wheel
           REQUIRE_SPEEDUPS=1 python3 setup.py build_ext -i
@@ -136,11 +134,11 @@ jobs:
             arch: "x86_64 universal2 arm64"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
@@ -163,7 +161,7 @@ jobs:
           CIBW_SKIP: "pp*"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}
@@ -173,7 +171,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         name: Install Python
@@ -197,7 +195,7 @@ jobs:
           cd simplejson-*
           REQUIRE_SPEEDUPS=1 python setup.py build build_ext -i test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
         with:
           name: sdist
@@ -240,7 +238,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist
@@ -260,7 +258,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -159,8 +159,9 @@ jobs:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_ARCHS: ${{ matrix.arch }}
-          # PyPy wheels are covered by the test_pure_python job.
-          CIBW_SKIP: "pp*"
+          # PyPy is disabled by default in cibuildwheel v3.x, so no
+          # CIBW_SKIP needed for it (and adding one makes v3.4 error
+          # out with "Invalid skip selector: 'pp*'").
 
       - name: Build Python 2.7 wheels
         if: runner.os == 'Linux' && matrix.arch == 'x86_64'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,57 +63,29 @@ jobs:
   test_debug_build:
     name: Tests on Python 3.14 debug build
     runs-on: ubuntu-latest
-    env:
-      # Pin the Python version so the cache key is stable. Bump when
-      # we want to pick up a new 3.14.x release.
-      PYTHON_VERSION: '3.14.4'
-      PYTHON_PREFIX: /opt/python-debug
     steps:
       - uses: actions/checkout@v6
-
-      - name: Cache Python debug build
-        id: cache-python
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.PYTHON_PREFIX }}
-          key: python-${{ env.PYTHON_VERSION }}-debug-${{ runner.os }}-v1
-
-      - name: Build Python ${{ env.PYTHON_VERSION }} with --with-pydebug
-        if: steps.cache-python.outputs.cache-hit != 'true'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+      - name: Install Python 3.14.4 debug build via python-build-standalone
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential libssl-dev zlib1g-dev libbz2-dev \
-            libreadline-dev libsqlite3-dev libffi-dev liblzma-dev
-          curl -fsSL -o Python.tar.xz \
-            "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
-          tar xf Python.tar.xz
-          cd Python-${PYTHON_VERSION}
-          ./configure --with-pydebug --disable-test-modules \
-            --prefix="${PYTHON_PREFIX}" --with-ensurepip=install
-          make -j "$(nproc)"
-          sudo make install
-          sudo chown -R "$(id -u):$(id -g)" "${PYTHON_PREFIX}"
-
-      - name: Add debug Python to PATH
-        run: echo "${PYTHON_PREFIX}/bin" >> "$GITHUB_PATH"
-
+          uv python install cpython-3.14.4+debug
+          uv venv --python cpython-3.14.4+debug .venv
+          uv pip install --python .venv/bin/python setuptools wheel
       - name: Verify debug build
         run: |
-          python3 -c "
+          .venv/bin/python -c "
           import sys
           assert hasattr(sys, 'gettotalrefcount'), (
               'not a debug build (sys.gettotalrefcount missing)')
           print('OK:', sys.version)
           "
-
-      - name: Build extension
-        run: |
-          python3 -m pip install --upgrade setuptools wheel
-          REQUIRE_SPEEDUPS=1 python3 setup.py build_ext -i
-
+      - name: Build extension with strict warnings (-Werror)
+        env:
+          CFLAGS: "-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type"
+        run: REQUIRE_SPEEDUPS=1 .venv/bin/python setup.py build_ext -i
       - name: Run tests (TestRefcountLeaks auto-enabled on debug build)
-        run: python3 -m simplejson.tests._cibw_runner .
+        run: .venv/bin/python -m simplejson.tests._cibw_runner .
 
   build_wheels:
     name: Build wheels (${{ matrix.os }}, ${{ matrix.arch }})

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,7 +25,7 @@ jobs:
           - graalpy-25.0
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - run: python -m simplejson.tests._cibw_runner .
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.14t'
       - name: Verify Python is a free-threaded build
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.14'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,6 +38,17 @@ jobs:
       - uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.14t'
+      - name: Verify Python is a free-threaded build
+        run: |
+          python -c "
+          import sys, sysconfig
+          gil_disabled = sysconfig.get_config_var('Py_GIL_DISABLED')
+          assert gil_disabled == 1, (
+              'Python is not a free-threaded build '
+              '(Py_GIL_DISABLED={!r}); setup-python did not install 3.14t.'
+              .format(gil_disabled))
+          print('OK: Py_GIL_DISABLED=1, sys.version=' + sys.version)
+          "
       - name: Build extension with free-threading support
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
 
       - name: Build Python 2.7 wheels
-        if: runner.os == 'Linux' && matrix.arch != 'ppc64le'
+        if: runner.os == 'Linux' && matrix.arch == 'x86_64'
         uses: pypa/cibuildwheel@v1.12.0
         env:
           CIBW_TEST_COMMAND: >-

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -83,6 +83,11 @@ jobs:
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_ENABLE: "cpython-freethreading"
           CIBW_ARCHS: ${{ matrix.arch }}
+          # Skip PyPy wheels (covered by the pure-Python test job).
+          # Skip Python 3.8 on Windows: cibuildwheel 3.4.1 ships a
+          # virtualenv that cannot bootstrap Python 3.8 on Windows,
+          # and 3.8 has been EOL since October 2024.
+          CIBW_SKIP: "pp* cp38-win*"
 
       - name: Build Python 2.7 wheels
         if: runner.os == 'Linux' && matrix.arch == 'x86_64'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,8 +53,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           REQUIRE_SPEEDUPS=1 python setup.py build_ext -i
-      - name: Verify GIL-free import (no RuntimeWarning)
-        run: PYTHON_GIL=0 python -W error::RuntimeWarning -c "import simplejson._speedups"
+      - name: Verify GIL-free import and C speedups loaded
+        run: |
+          PYTHON_GIL=0 python -W error::RuntimeWarning -c "
+          import simplejson, simplejson.encoder, simplejson.scanner
+          from simplejson._speedups import make_encoder, make_scanner
+          assert simplejson.encoder.c_make_encoder is make_encoder, 'c_make_encoder not wired'
+          assert simplejson.scanner.c_make_scanner is make_scanner, 'c_make_scanner not wired'
+          print('OK: C speedups loaded and wired in')
+          "
       - name: Run tests
         run: python -m simplejson.tests._cibw_runner .
       - name: Run tests with GIL disabled
@@ -84,6 +91,15 @@ jobs:
         env:
           CFLAGS: "-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type"
         run: REQUIRE_SPEEDUPS=1 .venv/bin/python setup.py build_ext -i
+      - name: Verify C speedups loaded
+        run: |
+          .venv/bin/python -c "
+          import simplejson, simplejson.encoder, simplejson.scanner
+          from simplejson._speedups import make_encoder, make_scanner
+          assert simplejson.encoder.c_make_encoder is make_encoder, 'c_make_encoder not wired'
+          assert simplejson.scanner.c_make_scanner is make_scanner, 'c_make_scanner not wired'
+          print('OK: C speedups loaded and wired in')
+          "
       - name: Run tests (TestRefcountLeaks auto-enabled on debug build)
         run: .venv/bin/python -m simplejson.tests._cibw_runner .
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -136,6 +136,28 @@ jobs:
             dist/*.tar.gz
             dist/*-none-any.whl
 
+  # Aggregate gate jobs to match branch protection rule names
+  gate_ubuntu:
+    name: Build wheels on ubuntu-latest
+    needs: [build_wheels, test_pure_python, test_free_threading]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All ubuntu-latest checks passed"
+
+  gate_windows:
+    name: Build wheels on windows-latest
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All windows-latest checks passed"
+
+  gate_macos:
+    name: Build wheels on macos-latest
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All macos-latest checks passed"
+
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -81,13 +81,9 @@ jobs:
         env:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"
-          CIBW_ENABLE: "cpython-freethreading"
           CIBW_ARCHS: ${{ matrix.arch }}
-          # Skip PyPy wheels (covered by the pure-Python test job).
-          # Skip Python 3.8 on Windows: cibuildwheel 3.4.1 ships a
-          # virtualenv that cannot bootstrap Python 3.8 on Windows,
-          # and 3.8 has been EOL since October 2024.
-          CIBW_SKIP: "pp* cp38-win*"
+          # PyPy wheels are covered by the test_pure_python job.
+          CIBW_SKIP: "pp*"
 
       - name: Build Python 2.7 wheels
         if: runner.os == 'Linux' && matrix.arch == 'x86_64'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -68,16 +68,27 @@ jobs:
         run: PYTHON_GIL=0 python -m simplejson.tests._cibw_runner .
 
   test_debug_build:
-    name: Tests on Python 3.14 debug build
+    name: Tests on Python 3.14 ${{ matrix.variant }} debug build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - "standard"
+          - "free-threaded"
+        include:
+          - variant: "standard"
+            uv_python: "cpython-3.14.4+debug"
+          - variant: "free-threaded"
+            uv_python: "cpython-3.14.4+freethreaded+debug"
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
-      - name: Install Python 3.14.4 debug build via python-build-standalone
+      - name: Install Python via python-build-standalone (${{ matrix.uv_python }})
         run: |
-          uv python install cpython-3.14.4+debug
-          uv venv --python cpython-3.14.4+debug .venv
+          uv python install ${{ matrix.uv_python }}
+          uv venv --python ${{ matrix.uv_python }} .venv
           uv pip install --python .venv/bin/python setuptools wheel
       - name: Verify debug build
         run: |
@@ -86,6 +97,15 @@ jobs:
           assert hasattr(sys, 'gettotalrefcount'), (
               'not a debug build (sys.gettotalrefcount missing)')
           print('OK:', sys.version)
+          "
+      - name: Verify free-threaded build
+        if: matrix.variant == 'free-threaded'
+        run: |
+          .venv/bin/python -c "
+          import sysconfig
+          assert sysconfig.get_config_var('Py_GIL_DISABLED') == 1, (
+              'expected free-threaded build (Py_GIL_DISABLED=1)')
+          print('OK: Py_GIL_DISABLED=1')
           "
       - name: Build extension with strict warnings (-Werror)
         env:
@@ -102,6 +122,9 @@ jobs:
           "
       - name: Run tests (TestRefcountLeaks auto-enabled on debug build)
         run: .venv/bin/python -m simplejson.tests._cibw_runner .
+      - name: Run tests with GIL disabled
+        if: matrix.variant == 'free-threaded'
+        run: PYTHON_GIL=0 .venv/bin/python -m simplejson.tests._cibw_runner .
 
   build_wheels:
     name: Build wheels (${{ matrix.os }}, ${{ matrix.arch }})

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.6.0.6.0
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.14t'
       - name: Build extension with free-threading support

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 *.pyd
 .DS_Store
+/.claude/
 /MANIFEST
 /.coverage
 /coverage.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,12 +189,18 @@ from simplejson.tests._helpers import skip_if_speedups_missing
 ## Useful CFLAGS combinations
 
 ```bash
-# Everything on, matches the test_debug_build CI job
+# Everything on, matches the test_debug_build CI job. Use this for
+# the standard (non-free-threaded) debug and release builds.
 CFLAGS="-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror \
         -Wno-unused-parameter -Wno-missing-field-initializers \
         -Wno-cast-function-type"
 
-# Add -Wdeclaration-after-statement to verify the file stays C89-clean
+# Add -Wdeclaration-after-statement to verify the file stays C89-clean.
+# Works on standard and standard-debug builds but NOT on free-threaded
+# builds: cp314t's own `refcount.h` has a mixed-decls-and-code block
+# (around refcount.h:113) that trips -Werror before your source is
+# even compiled. Use the plain CFLAGS above when building against
+# cpython-3.14+freethreaded+debug.
 CFLAGS="-Wall -Wextra -Wshadow -Wstrict-prototypes -Wdeclaration-after-statement \
         -Werror -Wno-unused-parameter -Wno-missing-field-initializers \
         -Wno-cast-function-type"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,205 @@
+# AGENTS.md
+
+Notes for Claude and other agents working on simplejson. This is
+tribal knowledge that isn't obvious from reading the source — the
+code structure itself is straightforward enough; what's collected
+here is the workflow, debugging tricks, and pitfalls specifically
+learned during the 3.14t / free-threading port.
+
+## Testing against alternate Python versions locally
+
+Use `uv` + `python-build-standalone`, **not** `apt install python3.X-dbg`
+and **not** building CPython from source. uv pulls prebuilt CPython
+variants (including debug and free-threaded debug) in under 10 seconds:
+
+```bash
+# Regular release (same thing setup-python installs in CI)
+uv python install cpython-3.14.4
+
+# Debug build — exposes sys.gettotalrefcount, Py_DECREF asserts,
+# and the internal consistency checks release builds skip. This is
+# the variant that caught the -1LL << n UB bug.
+uv python install cpython-3.14.4+debug
+
+# Free-threaded + debug — highest-value single variant for this PR.
+# Stacks refcount asserts, GIL-disabled scheduling, and the
+# specializer in one interpreter.
+uv python install cpython-3.14.4+freethreaded+debug
+```
+
+Each installed Python is a self-contained directory under
+`~/.local/share/uv/python/`. Make a venv and install `setuptools`+
+`wheel` with `uv pip`:
+
+```bash
+uv venv --python cpython-3.14.4+debug /tmp/debug-venv
+uv pip install --python /tmp/debug-venv/bin/python setuptools wheel
+rm -f simplejson/_speedups*.so
+REQUIRE_SPEEDUPS=1 /tmp/debug-venv/bin/python setup.py build_ext -i
+/tmp/debug-venv/bin/python -m simplejson.tests._cibw_runner .
+```
+
+**Always use `_cibw_runner`, not `python -m unittest discover`.** The
+runner runs the full test suite twice: once with the C speedups
+loaded, once via `NoExtensionTestSuite` with `simplejson._toggle_speedups(False)`
+to exercise the pure-Python path. `unittest discover` only hits
+the C path.
+
+## What uv can't give you: Python 2.7
+
+python-build-standalone does not ship Py2.7 binaries. There is **no
+way to test Py2 locally**. When touching code that affects the Py2
+bytes parser path in `_speedups.c` or `_speedups_scan.h`, the loop is:
+
+1. Reason about the change on paper (macro expansions, declarations
+   vs statements, refcount transitions)
+2. Push a commit
+3. Wait for the `Build Python 2.7 wheels` step in the wheel job
+   (uses `pypa/cibuildwheel@v1.12.0` / manylinux1 / gcc 4.8)
+
+## Reading CI failures
+
+The GitHub Actions raw logs endpoint requires **admin** permissions —
+the API returns 403 for anyone else, and `WebFetch` against a job
+page only sees the failure *annotations*, not the actual step output.
+
+When you see an annotation like `pip wheel ... failed with code 1`
+and no detail:
+
+1. Reproduce locally across `python3.10`..`python3.14.4` and both
+   free-threaded + debug via uv. 90% of real failures reproduce.
+2. Check if the run is **stale** — compare the run's head SHA
+   against the branch head. `mcp__github__list_commits` for the
+   branch, and compare with run URLs or `mcp__github__list_pull_requests`.
+   CI runs frequently lag by seconds, and multiple pushes within
+   ~30 seconds will leave stale failure notifications in the
+   webhook stream.
+3. If the local reproduction is clean, ask the user to paste the
+   raw log lines. This is almost always faster than guessing.
+
+## cibuildwheel gotchas on this repo
+
+Two cibuildwheel versions run in one job:
+
+- **Main `Build wheels` step** uses `pypa/cibuildwheel@v3.4.1` (Py3).
+  In v3.x **PyPy is disabled by default**; `CIBW_SKIP: "pp*"` *errors*
+  with `Invalid skip selector: 'pp*'. This selector matches a group
+  that wasn't enabled.` Do not set it.
+- **`Build Python 2.7 wheels` step** uses `pypa/cibuildwheel@v1.12.0`.
+  That version *does* build PyPy by default, so this step **must**
+  keep `CIBW_SKIP: "pp*"`.
+- `CIBW_ENABLE: "cpython-freethreading"` is deprecated in v3.4+
+  (free-threaded builds are on by default). Remove it.
+
+## Extension module reload does not actually reload
+
+`importlib.reload(simplejson._speedups)` and
+`del sys.modules['simplejson._speedups']; import simplejson._speedups`
+both return the **same cached module object** from CPython's import
+cache — `module_exec` is not re-run. The only scenario that actually
+triggers a fresh `module_exec` against the pre-3.13 static state is
+a **subinterpreter import on Python 3.5–3.11**. That's why
+`reset_speedups_state_constants` exists as defense-in-depth, but
+it's nearly impossible to exercise from a unit test. Don't waste
+time writing one.
+
+## Refcount leak tests flake on 3.14 debug
+
+CPython 3.14 debug has non-trivial per-call refcount drift from
+specializer inline caches settling in — up to ~272 refs over 2000
+iterations of `simplejson.dumps(...)` with no real leak.
+`TestRefcountLeaks` in `test_speedups.py` uses a **two-phase**
+measurement: warmup + first 2000 iters absorb the noise, second
+2000 iters should show <10 refs. **Assert on phase 2 only.**
+Asserting on the total delta will flake.
+
+## Python 3.14 release has `-Wunreachable-code` in its default CFLAGS
+
+Earlier Python versions don't. A local release build with `-Werror`
+will pass on 3.11/3.12/3.13 and fail on 3.14 if you introduce any
+unreachable code on a hot path. Always spot-check with
+`cpython-3.14.4` specifically when doing C refactors.
+
+## `_speedups_scan.h` is included **twice**
+
+From `_speedups.c`, once with `JSON_SCAN_SUFFIX=_unicode` (used by
+every Python 3 and by Py2 unicode input) and once on Py2 with
+`JSON_SCAN_SUFFIX=_str`. The macros are `#undef`-ed at the bottom
+of the file so the second include can redefine them. GCC's
+multi-include-guard optimization does not kick in because the only
+`#ifndef` in the file is a sanity check on `JSON_SCAN_SUFFIX`, not
+a wrap-the-whole-file include guard.
+
+`scan_once`, `_parse_object`, `_parse_array`, and `_match_number`
+live in the template. `scanstring_str` and `scanstring_unicode` do
+**not** — they remain separate because `scanstring_str` has a Py2
+hybrid return type (bytes when ASCII-only, unicode otherwise) that
+the template can't cleanly express. Don't try to pull them in.
+
+## Don't `Py_CLEAR` type fields in `reset_speedups_state_constants`
+
+On pre-3.13, `state->PyScannerType` and `state->PyEncoderType` hold
+**borrowed** pointers to static `PyTypeObject` bodies defined later
+in the file. They must never be refcounted. The reset helper is for
+*constants* only; `speedups_clear` on 3.13+ handles type fields
+separately.
+
+## `REQUIRE_SPEEDUPS=1` only affects the build, not tests
+
+It makes `setup.py build_ext` fail loudly instead of falling back to
+pure-Python. It is a **no-op** on `python -m unittest` or
+`_cibw_runner` invocations. If the built `.so` is subtly broken
+(e.g. imports but `simplejson.encoder.c_make_encoder is None`), the
+test runner's `TestMissingSpeedups` calls `skipTest()` not `fail()`
+and the whole C-extension suite silently passes as "all skipped".
+
+Both `test_free_threading` and `test_debug_build` CI jobs include
+an explicit wiring check:
+
+```python
+import simplejson, simplejson.encoder, simplejson.scanner
+from simplejson._speedups import make_encoder, make_scanner
+assert simplejson.encoder.c_make_encoder is make_encoder
+assert simplejson.scanner.c_make_scanner is make_scanner
+```
+
+**Keep this check.** It's the only thing that catches a silently-
+broken wheel.
+
+## GitHub Actions version pinning landmines
+
+- `astral-sh/setup-uv` floating `@v8` tag didn't exist when this PR
+  was written — only the pinned `@v8.0.0`. Web searches may
+  confidently tell you `v8` exists when it doesn't. Verify via
+  `git ls-remote --tags`.
+- `actions/setup-python@v5` floats and works fine; no version
+  landmine there.
+- Pinning `@v5.6.0.6.0` (mangled) is an easy typo that silently
+  doesn't resolve. Double-check the exact tag string before trusting.
+
+## Test helpers live in `simplejson/tests/_helpers.py`
+
+`has_speedups()` and `skip_if_speedups_missing()` are **not** defined
+in each test file. Import them:
+
+```python
+from simplejson.tests._helpers import skip_if_speedups_missing
+```
+
+## Useful CFLAGS combinations
+
+```bash
+# Everything on, matches the test_debug_build CI job
+CFLAGS="-Wall -Wextra -Wshadow -Wstrict-prototypes -Werror \
+        -Wno-unused-parameter -Wno-missing-field-initializers \
+        -Wno-cast-function-type"
+
+# Add -Wdeclaration-after-statement to verify the file stays C89-clean
+CFLAGS="-Wall -Wextra -Wshadow -Wstrict-prototypes -Wdeclaration-after-statement \
+        -Werror -Wno-unused-parameter -Wno-missing-field-initializers \
+        -Wno-cast-function-type"
+```
+
+`-Wno-unused-parameter` and `-Wno-missing-field-initializers` are
+necessary because Python's own headers trigger them — removing them
+causes a build failure that's not your fault. Keep them suppressed.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include *.txt
 include *.rst
 include scripts/*.py
 include MANIFEST.in
+include simplejson/*.h

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,11 @@ def run_setup(with_binary):
     if with_binary:
         kw = dict(
             ext_modules=[
-                Extension("simplejson._speedups", ["simplejson/_speedups.c"]),
+                Extension(
+                    "simplejson._speedups",
+                    sources=["simplejson/_speedups.c"],
+                    depends=["simplejson/_speedups_scan.h"],
+                ),
             ],
             cmdclass=dict(cmdclass, build_ext=ve_build_ext),
         )

--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -133,7 +133,6 @@ from .errors import JSONDecodeError
 from .raw_json import RawJSON
 from .decoder import JSONDecoder
 from .encoder import JSONEncoder, JSONEncoderForHTML
-from .compat import is_gil_enabled
 
 def _import_OrderedDict():
     import collections
@@ -145,8 +144,6 @@ def _import_OrderedDict():
 OrderedDict = _import_OrderedDict()
 
 def _import_c_make_encoder():
-    if not is_gil_enabled():
-        return None
     try:
         from ._speedups import make_encoder
         return make_encoder

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -91,6 +91,24 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
 typedef struct {
     PyObject *PyScannerType;
     PyObject *PyEncoderType;
+    /* Constants – per-module state instead of file-scope globals */
+    PyObject *JSON_Infinity;
+    PyObject *JSON_NegInfinity;
+    PyObject *JSON_NaN;
+    PyObject *JSON_EmptyUnicode;
+    PyObject *JSON_s_null;
+    PyObject *JSON_s_true;
+    PyObject *JSON_s_false;
+    PyObject *JSON_open_dict;
+    PyObject *JSON_close_dict;
+    PyObject *JSON_empty_dict;
+    PyObject *JSON_open_array;
+    PyObject *JSON_close_array;
+    PyObject *JSON_empty_array;
+    PyObject *JSON_sortargs;
+    PyObject *JSON_itemgetter0;
+    PyObject *RawJSONType;
+    PyObject *JSONDecodeError;
 } _speedups_state;
 
 static inline _speedups_state *
@@ -100,6 +118,9 @@ get_speedups_state(PyObject *module)
     assert(state != NULL);
     return (_speedups_state *)state;
 }
+
+/* Forward declaration - defined later with multi-phase init */
+static struct PyModuleDef moduledef;
 #endif /* PY_VERSION_HEX >= 0x030D0000 */
 
 #if PY_VERSION_HEX < 0x030D0000
@@ -114,6 +135,7 @@ static PyTypeObject PyEncoderType;
 #define JSON_ALLOW_NAN 1
 #define JSON_IGNORE_NAN 2
 
+#if PY_VERSION_HEX < 0x030D0000
 static PyObject *JSON_Infinity = NULL;
 static PyObject *JSON_NegInfinity = NULL;
 static PyObject *JSON_NaN = NULL;
@@ -136,10 +158,14 @@ static PyObject *JSON_close_array = NULL;
 static PyObject *JSON_empty_array = NULL;
 static PyObject *JSON_sortargs = NULL;
 static PyObject *JSON_itemgetter0 = NULL;
+#endif /* PY_VERSION_HEX < 0x030D0000 */
 
 typedef struct {
     PyObject *large_strings;  /* A list of previously accumulated large strings */
     PyObject *small_strings;  /* Pending small strings */
+#if PY_VERSION_HEX >= 0x030D0000
+    PyObject *empty_unicode;  /* Borrowed ref to state->JSON_EmptyUnicode */
+#endif
 } JSON_Accu;
 
 static int
@@ -168,6 +194,9 @@ JSON_Accu_Destroy(JSON_Accu *acc);
 
 typedef struct _PyScannerObject {
     PyObject_HEAD
+#if PY_VERSION_HEX >= 0x030D0000
+    PyObject *module_ref;
+#endif
     PyObject *encoding;
     PyObject *strict_bool;
     int strict;
@@ -192,6 +221,9 @@ static PyMemberDef scanner_members[] = {
 
 typedef struct _PyEncoderObject {
     PyObject_HEAD
+#if PY_VERSION_HEX >= 0x030D0000
+    PyObject *module_ref;
+#endif
     PyObject *markers;
     PyObject *defaultfn;
     PyObject *encoder;
@@ -236,8 +268,13 @@ static PyMemberDef encoder_members[] = {
     {NULL}
 };
 
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+join_list_unicode(PyObject *lst, PyObject *empty_unicode);
+#else
 static PyObject *
 join_list_unicode(PyObject *lst);
+#endif
 static PyObject *
 JSON_ParseEncoding(PyObject *encoding);
 static PyObject *
@@ -262,8 +299,14 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
 static PyObject *
 _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 #endif
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
+                   PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError);
+#else
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr);
+#endif
 static PyObject *
 scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
@@ -280,8 +323,13 @@ static void
 encoder_dealloc(PyObject *self);
 static int
 encoder_clear(PyObject *self);
+#if PY_VERSION_HEX >= 0x030D0000
+static int
+is_raw_json(PyObject *obj, PyObject *RawJSONType);
+#else
 static int
 is_raw_json(PyObject *obj);
+#endif
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key);
 static int
@@ -290,10 +338,17 @@ static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level);
 static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level);
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+_encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false);
+static void
+raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError);
+#else
 static PyObject *
 _encoded_const(PyObject *obj);
 static void
 raise_errmsg(char *msg, PyObject *s, Py_ssize_t end);
+#endif
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -307,17 +362,37 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj);
 #if PY_VERSION_HEX < 0x030D0000
 static PyObject *
 moduleinit(void);
-#endif
 static int
 init_constants(void);
+#endif
 static PyObject *
 import_dependency(char *module_name, char *attr_name);
+
+/* Convenience macros for dual-signature utility functions.
+   On 3.13+ these pass per-module-state objects; on older versions
+   the functions use file-scope globals and the extra args are ignored. */
+#if PY_VERSION_HEX >= 0x030D0000
+#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg(msg, s, end, jde)
+#define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj, sn, st, sf)
+#define IS_RAW_JSON(obj, rjt) is_raw_json(obj, rjt)
+#define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst, eu)
+#define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
+    scanstring_unicode(pystr, end, strict, next_end_ptr, eu, jde)
+#else
+#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg(msg, s, end)
+#define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj)
+#define IS_RAW_JSON(obj, rjt) is_raw_json(obj)
+#define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst)
+#define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
+    scanstring_unicode(pystr, end, strict, next_end_ptr)
+#endif
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
 
 #define MIN_EXPANSION 6
 
+#if PY_VERSION_HEX < 0x030D0000
 static PyObject* RawJSONType = NULL;
 static int
 is_raw_json(PyObject *obj)
@@ -327,6 +402,16 @@ is_raw_json(PyObject *obj)
         return -1;
     return r;
 }
+#else
+static int
+is_raw_json(PyObject *obj, PyObject *RawJSONType)
+{
+    int r = PyObject_IsInstance(obj, RawJSONType);
+    if (r < 0)
+        return -1;
+    return r;
+}
+#endif
 
 static int
 JSON_Accu_Init(JSON_Accu *acc)
@@ -351,7 +436,9 @@ flush_accumulator(JSON_Accu *acc)
             if (acc->large_strings == NULL)
                 return -1;
         }
-#if PY_MAJOR_VERSION >= 3
+#if PY_VERSION_HEX >= 0x030D0000
+        joined = join_list_unicode(acc->small_strings, acc->empty_unicode);
+#elif PY_MAJOR_VERSION >= 3
         joined = join_list_unicode(acc->small_strings);
 #else /* PY_MAJOR_VERSION >= 3 */
         joined = join_list_string(acc->small_strings);
@@ -674,6 +761,12 @@ ascii_escape_str(PyObject *pystr)
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 {
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_s_null = _st->JSON_s_null;
+    PyObject *JSON_s_true = _st->JSON_s_true;
+    PyObject *JSON_s_false = _st->JSON_s_false;
+#endif
     if (PyUnicode_Check(key)) {
         Py_INCREF(key);
         return key;
@@ -701,7 +794,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
     else if (key == Py_True || key == Py_False || key == Py_None) {
         /* This must come before the PyInt_Check because
            True and False are also 1 and 0.*/
-        return _encoded_const(key);
+        return ENCODED_CONST(key, JSON_s_null, JSON_s_true, JSON_s_false);
     }
     else if (PyInt_Check(key) || PyLong_Check(key)) {
         if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
@@ -735,6 +828,10 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 static PyObject *
 encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
 {
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_sortargs = _st->JSON_sortargs;
+#endif
     PyObject *items;
     PyObject *iter = NULL;
     PyObject *lst = NULL;
@@ -823,6 +920,7 @@ bail:
 }
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
+#if PY_VERSION_HEX < 0x030D0000
 static PyObject *JSONDecodeError = NULL;
 static void
 raise_errmsg(char *msg, PyObject *s, Py_ssize_t end)
@@ -833,13 +931,33 @@ raise_errmsg(char *msg, PyObject *s, Py_ssize_t end)
         Py_DECREF(exc);
     }
 }
+#else
+static void
+raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
+{
+    PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
+    if (exc) {
+        PyErr_SetObject(JSONDecodeError, exc);
+        Py_DECREF(exc);
+    }
+}
+#endif
 
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+join_list_unicode(PyObject *lst, PyObject *empty_unicode)
+{
+    /* return u''.join(lst) */
+    return PyUnicode_Join(empty_unicode, lst);
+}
+#else
 static PyObject *
 join_list_unicode(PyObject *lst)
 {
     /* return u''.join(lst) */
     return PyUnicode_Join(JSON_EmptyUnicode, lst);
 }
+#endif
 
 #if PY_MAJOR_VERSION >= 3
 #define join_list_string join_list_unicode
@@ -1109,8 +1227,14 @@ bail:
 }
 #endif /* PY_MAJOR_VERSION < 3 */
 
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
+                   PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError)
+#else
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr)
+#endif
 {
     /* Read the JSON string from PyUnicode pystr.
     end is the index of the first character after the quote.
@@ -1130,7 +1254,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     PyObject *chunk = NULL;
 
     if (len == end) {
-        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+        RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -1146,12 +1270,12 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 break;
             }
             else if (strict && c <= 0x1f) {
-                raise_errmsg(ERR_STRING_CONTROL, pystr, next);
+                RAISE_ERRMSG(ERR_STRING_CONTROL, pystr, next, JSONDecodeError);
                 goto bail;
             }
         }
         if (!(c == '"' || c == '\\')) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+            RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -1172,7 +1296,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             break;
         }
         if (next == len) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+            RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
             goto bail;
         }
         c = PyUnicode_READ(kind, buf, next);
@@ -1191,7 +1315,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2);
+                RAISE_ERRMSG(ERR_STRING_ESC1, pystr, end - 2, JSONDecodeError);
                 goto bail;
             }
         }
@@ -1200,7 +1324,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             next++;
             end = next + 4;
             if (end >= len) {
-                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1);
+                RAISE_ERRMSG(ERR_STRING_ESC4, pystr, next - 1, JSONDecodeError);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1218,7 +1342,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5);
+                        RAISE_ERRMSG(ERR_STRING_ESC4, pystr, end - 5, JSONDecodeError);
                         goto bail;
                 }
             }
@@ -1245,7 +1369,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5);
+                            RAISE_ERRMSG(ERR_STRING_ESC4, pystr, end - 5, JSONDecodeError);
                             goto bail;
                         }
                     }
@@ -1278,7 +1402,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     }
     else {
         APPEND_OLD_CHUNK
-        rval = join_list_unicode(chunks);
+        rval = JOIN_LIST_UNICODE(chunks, JSON_EmptyUnicode);
         if (rval == NULL) {
             goto bail;
         }
@@ -1324,7 +1448,15 @@ py_scanstring(PyObject* self UNUSED, PyObject *args)
     if (PyUnicode_Check(pystr)) {
         if (PyUnicode_READY(pystr))
             return NULL;
+#if PY_VERSION_HEX >= 0x030D0000
+        {
+            _speedups_state *_st = get_speedups_state(self);
+            rval = scanstring_unicode(pystr, end, strict, &next_end,
+                                      _st->JSON_EmptyUnicode, _st->JSONDecodeError);
+        }
+#else
         rval = scanstring_unicode(pystr, end, strict, &next_end);
+#endif
     }
 #if PY_MAJOR_VERSION < 3
     /* Using a bytes input is unsupported for scanning in Python 3.
@@ -1394,6 +1526,7 @@ scanner_traverse(PyObject *self, visitproc visit, void *arg)
     s = (PyScannerObject *)self;
 #if PY_VERSION_HEX >= 0x030D0000
     Py_VISIT(Py_TYPE(self));
+    Py_VISIT(s->module_ref);
 #endif
     Py_VISIT(s->encoding);
     Py_VISIT(s->strict_bool);
@@ -1414,6 +1547,9 @@ scanner_clear(PyObject *self)
     assert(PyScanner_Check(self));
 #endif
     s = (PyScannerObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_CLEAR(s->module_ref);
+#endif
     Py_CLEAR(s->encoding);
     Py_CLEAR(s->strict_bool);
     Py_CLEAR(s->object_hook);
@@ -1600,6 +1736,11 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
     Returns a new PyObject (usually a dict, but object_hook can change that)
     */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
+    PyObject *JSONDecodeError = _st->JSONDecodeError;
+#endif
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
@@ -1635,10 +1776,10 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
             /* read key */
             if (PyUnicode_READ(kind, str, idx) != '"') {
-                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx);
+                RAISE_ERRMSG(ERR_OBJECT_PROPERTY, pystr, idx, JSONDecodeError);
                 goto bail;
             }
-            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx);
+            key = SCANSTRING_UNICODE(pystr, idx + 1, s->strict, &next_idx, JSON_EmptyUnicode, JSONDecodeError);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1660,7 +1801,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                whitespace */
             while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
             if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
-                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
+                RAISE_ERRMSG(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, JSONDecodeError);
                 goto bail;
             }
             idx++;
@@ -1702,7 +1843,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx);
+                RAISE_ERRMSG(ERR_OBJECT_DELIMITER, pystr, idx, JSONDecodeError);
                 goto bail;
             }
             idx++;
@@ -1712,7 +1853,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx);
+            RAISE_ERRMSG(ERR_OBJECT_PROPERTY, pystr, idx, JSONDecodeError);
             goto bail;
         }
     }
@@ -1720,9 +1861,9 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
         if (did_parse) {
-            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx);
+            RAISE_ERRMSG(ERR_OBJECT_DELIMITER, pystr, idx, JSONDecodeError);
         } else {
-            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
+            RAISE_ERRMSG(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, JSONDecodeError);
         }
         goto bail;
     }
@@ -1847,6 +1988,10 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
 
     Returns a new PyList
     */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSONDecodeError = _st->JSONDecodeError;
+#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -1885,7 +2030,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx);
+                RAISE_ERRMSG(ERR_ARRAY_DELIMITER, pystr, idx, JSONDecodeError);
                 goto bail;
             }
             idx++;
@@ -1895,7 +2040,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx);
+            RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
             goto bail;
         }
     }
@@ -1903,9 +2048,9 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
         if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx);
+            RAISE_ERRMSG(ERR_ARRAY_DELIMITER, pystr, idx, JSONDecodeError);
         } else {
-            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx);
+            RAISE_ERRMSG(ERR_ARRAY_VALUE_FIRST, pystr, idx, JSONDecodeError);
         }
         goto bail;
     }
@@ -1929,9 +2074,13 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
 
     Returns the result of parse_constant
     */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSONDecodeError = _st->JSONDecodeError;
+#endif
     PyObject *rval;
     if (s->parse_constant == Py_None) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx);
+        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
         return NULL;
     }
 
@@ -2062,6 +2211,10 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
         PyInt, PyLong, or PyFloat.
         May return other types if parse_int or parse_float are set
     */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSONDecodeError = _st->JSONDecodeError;
+#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -2074,7 +2227,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     /* read a sign if it's there, make sure it's not the end of the string */
     if (PyUnicode_READ(kind, str, idx) == '-') {
         if (idx >= end_idx) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start);
+            RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, start, JSONDecodeError);
             return NULL;
         }
         idx++;
@@ -2094,7 +2247,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     }
     else {
         /* no integer digits, error */
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start);
+        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, start, JSONDecodeError);
         return NULL;
     }
 
@@ -2279,21 +2432,29 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 
     Returns a new PyObject representation of the term.
     */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_NaN = _st->JSON_NaN;
+    PyObject *JSON_Infinity = _st->JSON_Infinity;
+    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
+    PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
+    PyObject *JSONDecodeError = _st->JSONDecodeError;
+#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t length = PyUnicode_GET_LENGTH(pystr);
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx);
+        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
         return NULL;
     }
     switch (PyUnicode_READ(kind, str, idx)) {
         case '"':
             /* string */
-            rval = scanstring_unicode(pystr, idx + 1,
+            rval = SCANSTRING_UNICODE(pystr, idx + 1,
                 s->strict,
-                next_idx_ptr);
+                next_idx_ptr, JSON_EmptyUnicode, JSONDecodeError);
             break;
         case '{':
             /* object */
@@ -2490,6 +2651,13 @@ scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (s == NULL)
         return NULL;
 
+#if PY_VERSION_HEX >= 0x030D0000
+    s->module_ref = PyType_GetModuleByDef(type, &moduledef);
+    if (s->module_ref == NULL)
+        goto bail;
+    Py_INCREF(s->module_ref);
+#endif
+
     if (s->memo == NULL) {
         s->memo = PyDict_New();
         if (s->memo == NULL)
@@ -2646,6 +2814,13 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (s == NULL)
         return NULL;
 
+#if PY_VERSION_HEX >= 0x030D0000
+    s->module_ref = PyType_GetModuleByDef(type, &moduledef);
+    if (s->module_ref == NULL)
+        goto bail;
+    Py_INCREF(s->module_ref);
+#endif
+
     Py_INCREF(markers);
     s->markers = markers;
     Py_INCREF(defaultfn);
@@ -2737,7 +2912,12 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (is_true < 0)
             goto bail;
         if (is_true) {
+#if PY_VERSION_HEX >= 0x030D0000
+            _speedups_state *_st = get_speedups_state(s->module_ref);
+            item_sort_key = _st->JSON_itemgetter0;
+#else
             item_sort_key = JSON_itemgetter0;
+#endif
             if (!item_sort_key)
                 goto bail;
         }
@@ -2789,6 +2969,12 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     if (JSON_Accu_Init(&rval))
         return NULL;
+#if PY_VERSION_HEX >= 0x030D0000
+    {
+        _speedups_state *_st = get_speedups_state(s->module_ref);
+        rval.empty_unicode = _st->JSON_EmptyUnicode;
+    }
+#endif
     Py_BEGIN_CRITICAL_SECTION(self);
     encode_rv = encoder_listencode_obj(s, &rval, obj, indent_level);
     Py_END_CRITICAL_SECTION();
@@ -2799,6 +2985,29 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     return JSON_Accu_FinishAsList(&rval);
 }
 
+#if PY_VERSION_HEX >= 0x030D0000
+static PyObject *
+_encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false)
+{
+    /* Return the JSON string representation of None, True, False */
+    if (obj == Py_None) {
+        Py_INCREF(JSON_s_null);
+        return JSON_s_null;
+    }
+    else if (obj == Py_True) {
+        Py_INCREF(JSON_s_true);
+        return JSON_s_true;
+    }
+    else if (obj == Py_False) {
+        Py_INCREF(JSON_s_false);
+        return JSON_s_false;
+    }
+    else {
+        PyErr_SetString(PyExc_ValueError, "not a const");
+        return NULL;
+    }
+}
+#else
 static PyObject *
 _encoded_const(PyObject *obj)
 {
@@ -2820,11 +3029,21 @@ _encoded_const(PyObject *obj)
         return NULL;
     }
 }
+#endif
 
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a PyFloat */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_Infinity = _st->JSON_Infinity;
+    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
+    PyObject *JSON_NaN = _st->JSON_NaN;
+    PyObject *JSON_s_null = _st->JSON_s_null;
+    PyObject *JSON_s_true = _st->JSON_s_true;
+    PyObject *JSON_s_false = _st->JSON_s_false;
+#endif
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         if (!s->allow_or_ignore_nan) {
@@ -2832,7 +3051,7 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
             return NULL;
         }
         if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
-            return _encoded_const(Py_None);
+            return ENCODED_CONST(Py_None, JSON_s_null, JSON_s_true, JSON_s_false);
         }
         /* JSON_ALLOW_NAN is set */
         else if (i > 0) {
@@ -2903,11 +3122,18 @@ static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level)
 {
     /* Encode Python object obj to a JSON term, rval is a PyList */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_s_null = _st->JSON_s_null;
+    PyObject *JSON_s_true = _st->JSON_s_true;
+    PyObject *JSON_s_false = _st->JSON_s_false;
+    PyObject *RawJSONType = _st->RawJSONType;
+#endif
     int rv = -1;
     do {
         PyObject *newobj;
         if (obj == Py_None || obj == Py_True || obj == Py_False) {
-            PyObject *cstr = _encoded_const(obj);
+            PyObject *cstr = ENCODED_CONST(obj, JSON_s_null, JSON_s_true, JSON_s_false);
             if (cstr != NULL)
                 rv = _steal_accumulate(rval, cstr);
         }
@@ -2997,7 +3223,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 rv = _steal_accumulate(rval, encoded);
         }
         else {
-            int raw = is_raw_json(obj);
+            int raw = IS_RAW_JSON(obj, RawJSONType);
             if (raw < 0)
                 break;
             if (raw) {
@@ -3071,6 +3297,12 @@ static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level)
 {
     /* Encode Python dict dct a JSON term */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_empty_dict = _st->JSON_empty_dict;
+    PyObject *JSON_open_dict = _st->JSON_open_dict;
+    PyObject *JSON_close_dict = _st->JSON_close_dict;
+#endif
     PyObject *kstr = NULL;
     PyObject *ident = NULL;
     PyObject *iter = NULL;
@@ -3206,6 +3438,12 @@ static int
 encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_ssize_t indent_level)
 {
     /* Encode Python list seq to a JSON term */
+#if PY_VERSION_HEX >= 0x030D0000
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_empty_array = _st->JSON_empty_array;
+    PyObject *JSON_open_array = _st->JSON_open_array;
+    PyObject *JSON_close_array = _st->JSON_close_array;
+#endif
     PyObject *ident = NULL;
     PyObject *iter = NULL;
     PyObject *obj = NULL;
@@ -3311,6 +3549,7 @@ encoder_traverse(PyObject *self, visitproc visit, void *arg)
     s = (PyEncoderObject *)self;
 #if PY_VERSION_HEX >= 0x030D0000
     Py_VISIT(Py_TYPE(self));
+    Py_VISIT(s->module_ref);
 #endif
     Py_VISIT(s->markers);
     Py_VISIT(s->defaultfn);
@@ -3339,6 +3578,9 @@ encoder_clear(PyObject *self)
     assert(PyEncoder_Check(self));
 #endif
     s = (PyEncoderObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_CLEAR(s->module_ref);
+#endif
     Py_CLEAR(s->markers);
     Py_CLEAR(s->defaultfn);
     Py_CLEAR(s->encoder);
@@ -3446,16 +3688,57 @@ module_exec(PyObject *m)
 {
     _speedups_state *state = get_speedups_state(m);
 
-    /* Create heap types from specs */
-    state->PyScannerType = PyType_FromSpec(&PyScannerType_spec);
+    /* Create heap types from specs, binding them to this module */
+    state->PyScannerType = PyType_FromModuleAndSpec(m, &PyScannerType_spec, NULL);
     if (state->PyScannerType == NULL)
         return -1;
 
-    state->PyEncoderType = PyType_FromSpec(&PyEncoderType_spec);
+    state->PyEncoderType = PyType_FromModuleAndSpec(m, &PyEncoderType_spec, NULL);
     if (state->PyEncoderType == NULL)
         return -1;
 
-    if (!init_constants())
+    /* Initialize all string constants into per-module state */
+    state->JSON_NaN = PyUnicode_InternFromString("NaN");
+    if (state->JSON_NaN == NULL)
+        return -1;
+    state->JSON_Infinity = PyUnicode_InternFromString("Infinity");
+    if (state->JSON_Infinity == NULL)
+        return -1;
+    state->JSON_NegInfinity = PyUnicode_InternFromString("-Infinity");
+    if (state->JSON_NegInfinity == NULL)
+        return -1;
+    state->JSON_EmptyUnicode = PyUnicode_New(0, 127);
+    if (state->JSON_EmptyUnicode == NULL)
+        return -1;
+    state->JSON_s_null = PyUnicode_InternFromString("null");
+    if (state->JSON_s_null == NULL)
+        return -1;
+    state->JSON_s_true = PyUnicode_InternFromString("true");
+    if (state->JSON_s_true == NULL)
+        return -1;
+    state->JSON_s_false = PyUnicode_InternFromString("false");
+    if (state->JSON_s_false == NULL)
+        return -1;
+    state->JSON_open_dict = PyUnicode_InternFromString("{");
+    if (state->JSON_open_dict == NULL)
+        return -1;
+    state->JSON_close_dict = PyUnicode_InternFromString("}");
+    if (state->JSON_close_dict == NULL)
+        return -1;
+    state->JSON_empty_dict = PyUnicode_InternFromString("{}");
+    if (state->JSON_empty_dict == NULL)
+        return -1;
+    state->JSON_open_array = PyUnicode_InternFromString("[");
+    if (state->JSON_open_array == NULL)
+        return -1;
+    state->JSON_close_array = PyUnicode_InternFromString("]");
+    if (state->JSON_close_array == NULL)
+        return -1;
+    state->JSON_empty_array = PyUnicode_InternFromString("[]");
+    if (state->JSON_empty_array == NULL)
+        return -1;
+    state->JSON_sortargs = PyTuple_New(0);
+    if (state->JSON_sortargs == NULL)
         return -1;
 
     if (PyModule_AddObjectRef(m, "make_scanner", state->PyScannerType) < 0)
@@ -3463,20 +3746,20 @@ module_exec(PyObject *m)
     if (PyModule_AddObjectRef(m, "make_encoder", state->PyEncoderType) < 0)
         return -1;
 
-    RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
-    if (RawJSONType == NULL)
+    state->RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
+    if (state->RawJSONType == NULL)
         return -1;
-    JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
-    if (JSONDecodeError == NULL)
+    state->JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
+    if (state->JSONDecodeError == NULL)
         return -1;
 
-    if (JSON_itemgetter0 == NULL) {
+    {
         PyObject *operator = PyImport_ImportModule("operator");
         if (!operator)
             return -1;
-        JSON_itemgetter0 = PyObject_CallMethod(operator, "itemgetter", "i", 0);
+        state->JSON_itemgetter0 = PyObject_CallMethod(operator, "itemgetter", "i", 0);
         Py_DECREF(operator);
-        if (!JSON_itemgetter0)
+        if (!state->JSON_itemgetter0)
             return -1;
     }
     return 0;
@@ -3488,6 +3771,23 @@ speedups_traverse(PyObject *m, visitproc visit, void *arg)
     _speedups_state *state = get_speedups_state(m);
     Py_VISIT(state->PyScannerType);
     Py_VISIT(state->PyEncoderType);
+    Py_VISIT(state->JSON_Infinity);
+    Py_VISIT(state->JSON_NegInfinity);
+    Py_VISIT(state->JSON_NaN);
+    Py_VISIT(state->JSON_EmptyUnicode);
+    Py_VISIT(state->JSON_s_null);
+    Py_VISIT(state->JSON_s_true);
+    Py_VISIT(state->JSON_s_false);
+    Py_VISIT(state->JSON_open_dict);
+    Py_VISIT(state->JSON_close_dict);
+    Py_VISIT(state->JSON_empty_dict);
+    Py_VISIT(state->JSON_open_array);
+    Py_VISIT(state->JSON_close_array);
+    Py_VISIT(state->JSON_empty_array);
+    Py_VISIT(state->JSON_sortargs);
+    Py_VISIT(state->JSON_itemgetter0);
+    Py_VISIT(state->RawJSONType);
+    Py_VISIT(state->JSONDecodeError);
     return 0;
 }
 
@@ -3497,6 +3797,23 @@ speedups_clear(PyObject *m)
     _speedups_state *state = get_speedups_state(m);
     Py_CLEAR(state->PyScannerType);
     Py_CLEAR(state->PyEncoderType);
+    Py_CLEAR(state->JSON_Infinity);
+    Py_CLEAR(state->JSON_NegInfinity);
+    Py_CLEAR(state->JSON_NaN);
+    Py_CLEAR(state->JSON_EmptyUnicode);
+    Py_CLEAR(state->JSON_s_null);
+    Py_CLEAR(state->JSON_s_true);
+    Py_CLEAR(state->JSON_s_false);
+    Py_CLEAR(state->JSON_open_dict);
+    Py_CLEAR(state->JSON_close_dict);
+    Py_CLEAR(state->JSON_empty_dict);
+    Py_CLEAR(state->JSON_open_array);
+    Py_CLEAR(state->JSON_close_array);
+    Py_CLEAR(state->JSON_empty_array);
+    Py_CLEAR(state->JSON_sortargs);
+    Py_CLEAR(state->JSON_itemgetter0);
+    Py_CLEAR(state->RawJSONType);
+    Py_CLEAR(state->JSONDecodeError);
     return 0;
 }
 
@@ -3540,6 +3857,7 @@ import_dependency(char *module_name, char *attr_name)
     return rval;
 }
 
+#if PY_VERSION_HEX < 0x030D0000
 static int
 init_constants(void)
 {
@@ -3596,6 +3914,7 @@ init_constants(void)
 
     return 1;
 }
+#endif /* PY_VERSION_HEX < 0x030D0000 */
 
 #if PY_VERSION_HEX < 0x030D0000
 /* Single-phase initialization for Python < 3.13 */

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2746,8 +2746,17 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (int_as_string_bitcount_val == -1 && PyErr_Occurred())
             goto bail;
         if (int_as_string_bitcount_val > 0 && int_as_string_bitcount_val < (long)long_long_bitsize) {
-            s->max_long_size = PyLong_FromUnsignedLongLong(1ULL << (int)int_as_string_bitcount_val);
-            s->min_long_size = PyLong_FromLongLong(-1LL << (int)int_as_string_bitcount_val);
+            int n = (int)int_as_string_bitcount_val;
+            /* Compute 2^n as unsigned (well-defined for n < 64) and
+             * -(2^n) as signed without UB. Naive "-1LL << n" is a
+             * shift of a negative value, which is undefined, and
+             * "-(1LL << n)" overflows when n == 63. The expression
+             * below avoids both: (1ULL << n) - 1 is always >= 0, so
+             * negating it and subtracting 1 stays in range and
+             * produces LLONG_MIN at n == 63. */
+            s->max_long_size = PyLong_FromUnsignedLongLong(1ULL << n);
+            s->min_long_size = PyLong_FromLongLong(
+                -(long long)((1ULL << n) - 1ULL) - 1LL);
             if (s->min_long_size == NULL || s->max_long_size == NULL) {
                 goto bail;
             }

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -151,9 +151,7 @@ get_speedups_state(PyObject *module)
 typedef struct {
     PyObject *large_strings;  /* A list of previously accumulated large strings */
     PyObject *small_strings;  /* Pending small strings */
-#if PY_MAJOR_VERSION >= 3
-    PyObject *empty_unicode;  /* Borrowed ref to state->JSON_EmptyUnicode */
-#endif
+    _speedups_state *state;   /* borrowed */
 } JSON_Accu;
 
 static int
@@ -253,7 +251,7 @@ static PyMemberDef encoder_members[] = {
 };
 
 static PyObject *
-join_list_unicode(PyObject *lst, PyObject *empty_unicode);
+join_list_unicode(PyObject *lst, _speedups_state *state);
 static PyObject *
 JSON_ParseEncoding(PyObject *encoding);
 static PyObject *
@@ -280,7 +278,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 #endif
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
-                   PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError);
+                   _speedups_state *state);
 static PyObject *
 scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
@@ -298,7 +296,7 @@ encoder_dealloc(PyObject *self);
 static int
 encoder_clear(PyObject *self);
 static int
-is_raw_json(PyObject *obj, PyObject *RawJSONType);
+is_raw_json(PyObject *obj, _speedups_state *state);
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key);
 static int
@@ -308,9 +306,9 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
 static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level);
 static PyObject *
-_encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false);
+_encoded_const(PyObject *obj, _speedups_state *state);
 static void
-raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError);
+raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state);
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -330,21 +328,11 @@ init_speedups_state(_speedups_state *state, PyObject *module);
 static PyObject *
 import_dependency(char *module_name, char *attr_name);
 
-/* Short aliases for helpers that take state-derived arguments. Defined
-   once for all Python versions now that the state layout is unified. */
-#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg_impl(msg, s, end, jde)
-#define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj, sn, st, sf)
-#define IS_RAW_JSON(obj, rjt) is_raw_json(obj, rjt)
-#define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst, eu)
-#define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
-    scanstring_unicode(pystr, end, strict, next_end_ptr, eu, jde)
-
 #if PY_MAJOR_VERSION < 3
-/* Python 2 call sites use a 3-arg form without threading state
-   through the scanner functions; resolve JSONDecodeError from the
-   static state at the call site. */
+/* Python 2 scanner functions don't thread state through explicitly,
+   so the 3-arg form resolves state from the single static instance. */
 #define raise_errmsg(msg, s, end) \
-    raise_errmsg_impl(msg, s, end, _speedups_static_state.JSONDecodeError)
+    raise_errmsg_impl(msg, s, end, &_speedups_static_state)
 #endif
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
@@ -353,9 +341,9 @@ import_dependency(char *module_name, char *attr_name);
 #define MIN_EXPANSION 6
 
 static int
-is_raw_json(PyObject *obj, PyObject *RawJSONType)
+is_raw_json(PyObject *obj, _speedups_state *state)
 {
-    int r = PyObject_IsInstance(obj, RawJSONType);
+    int r = PyObject_IsInstance(obj, state->RawJSONType);
     if (r < 0)
         return -1;
     return r;
@@ -369,11 +357,7 @@ JSON_Accu_Init(JSON_Accu *acc, _speedups_state *state)
     acc->small_strings = PyList_New(0);
     if (acc->small_strings == NULL)
         return -1;
-#if PY_MAJOR_VERSION >= 3
-    acc->empty_unicode = state->JSON_EmptyUnicode;  /* borrowed */
-#else
-    (void)state;
-#endif
+    acc->state = state;  /* borrowed */
     return 0;
 }
 
@@ -390,7 +374,7 @@ flush_accumulator(JSON_Accu *acc)
                 return -1;
         }
 #if PY_MAJOR_VERSION >= 3
-        joined = join_list_unicode(acc->small_strings, acc->empty_unicode);
+        joined = join_list_unicode(acc->small_strings, acc->state);
 #else
         joined = join_list_string(acc->small_strings);
 #endif
@@ -713,9 +697,6 @@ static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 {
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_s_null = _st->JSON_s_null;
-    PyObject *JSON_s_true = _st->JSON_s_true;
-    PyObject *JSON_s_false = _st->JSON_s_false;
     if (PyUnicode_Check(key)) {
         Py_INCREF(key);
         return key;
@@ -743,7 +724,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
     else if (key == Py_True || key == Py_False || key == Py_None) {
         /* This must come before the PyInt_Check because
            True and False are also 1 and 0.*/
-        return ENCODED_CONST(key, JSON_s_null, JSON_s_true, JSON_s_false);
+        return _encoded_const(key, _st);
     }
     else if (PyInt_Check(key) || PyLong_Check(key)) {
         if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
@@ -778,7 +759,6 @@ static PyObject *
 encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
 {
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_sortargs = _st->JSON_sortargs;
     PyObject *items;
     PyObject *iter = NULL;
     PyObject *lst = NULL;
@@ -849,7 +829,7 @@ encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
     sortfun = PyObject_GetAttrString(lst, "sort");
     if (sortfun == NULL)
         goto bail;
-    sortres = PyObject_Call(sortfun, JSON_sortargs, s->item_sort_kw);
+    sortres = PyObject_Call(sortfun, _st->JSON_sortargs, s->item_sort_kw);
     if (!sortres)
         goto bail;
     Py_DECREF(sortres);
@@ -868,8 +848,9 @@ bail:
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
 static void
-raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
+raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state)
 {
+    PyObject *JSONDecodeError = state->JSONDecodeError;
     PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
     if (exc) {
         PyErr_SetObject(JSONDecodeError, exc);
@@ -878,10 +859,10 @@ raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeEr
 }
 
 static PyObject *
-join_list_unicode(PyObject *lst, PyObject *empty_unicode)
+join_list_unicode(PyObject *lst, _speedups_state *state)
 {
     /* return u''.join(lst) */
-    return PyUnicode_Join(empty_unicode, lst);
+    return PyUnicode_Join(state->JSON_EmptyUnicode, lst);
 }
 
 #if PY_MAJOR_VERSION < 3
@@ -1152,7 +1133,7 @@ bail:
 
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
-                   PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError)
+                   _speedups_state *state)
 {
     /* Read the JSON string from PyUnicode pystr.
     end is the index of the first character after the quote.
@@ -1172,7 +1153,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     PyObject *chunk = NULL;
 
     if (len == end) {
-        RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
+        raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -1188,12 +1169,12 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 break;
             }
             else if (strict && c <= 0x1f) {
-                RAISE_ERRMSG(ERR_STRING_CONTROL, pystr, next, JSONDecodeError);
+                raise_errmsg_impl(ERR_STRING_CONTROL, pystr, next, state);
                 goto bail;
             }
         }
         if (!(c == '"' || c == '\\')) {
-            RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
+            raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -1214,7 +1195,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             break;
         }
         if (next == len) {
-            RAISE_ERRMSG(ERR_STRING_UNTERMINATED, pystr, begin, JSONDecodeError);
+            raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         c = PyUnicode_READ(kind, buf, next);
@@ -1233,7 +1214,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 default: c = 0;
             }
             if (c == 0) {
-                RAISE_ERRMSG(ERR_STRING_ESC1, pystr, end - 2, JSONDecodeError);
+                raise_errmsg_impl(ERR_STRING_ESC1, pystr, end - 2, state);
                 goto bail;
             }
         }
@@ -1242,7 +1223,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             next++;
             end = next + 4;
             if (end >= len) {
-                RAISE_ERRMSG(ERR_STRING_ESC4, pystr, next - 1, JSONDecodeError);
+                raise_errmsg_impl(ERR_STRING_ESC4, pystr, next - 1, state);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1260,7 +1241,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        RAISE_ERRMSG(ERR_STRING_ESC4, pystr, end - 5, JSONDecodeError);
+                        raise_errmsg_impl(ERR_STRING_ESC4, pystr, end - 5, state);
                         goto bail;
                 }
             }
@@ -1287,7 +1268,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            RAISE_ERRMSG(ERR_STRING_ESC4, pystr, end - 5, JSONDecodeError);
+                            raise_errmsg_impl(ERR_STRING_ESC4, pystr, end - 5, state);
                             goto bail;
                         }
                     }
@@ -1314,13 +1295,13 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
         if (chunk != NULL)
             rval = chunk;
         else {
-            rval = JSON_EmptyUnicode;
+            rval = state->JSON_EmptyUnicode;
             Py_INCREF(rval);
         }
     }
     else {
         APPEND_OLD_CHUNK
-        rval = JOIN_LIST_UNICODE(chunks, JSON_EmptyUnicode);
+        rval = join_list_unicode(chunks, state);
         if (rval == NULL) {
             goto bail;
         }
@@ -1366,11 +1347,8 @@ py_scanstring(PyObject* self UNUSED, PyObject *args)
     if (PyUnicode_Check(pystr)) {
         if (PyUnicode_READY(pystr))
             return NULL;
-        {
-            _speedups_state *_st = get_speedups_state(self);
-            rval = scanstring_unicode(pystr, end, strict, &next_end,
-                                      _st->JSON_EmptyUnicode, _st->JSONDecodeError);
-        }
+        rval = scanstring_unicode(pystr, end, strict, &next_end,
+                                  get_speedups_state(self));
     }
 #if PY_MAJOR_VERSION < 3
     /* Using a bytes input is unsupported for scanning in Python 3.
@@ -1647,8 +1625,6 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     Returns a new PyObject (usually a dict, but object_hook can change that)
     */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
-    PyObject *JSONDecodeError = _st->JSONDecodeError;
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
@@ -1684,10 +1660,10 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
             /* read key */
             if (PyUnicode_READ(kind, str, idx) != '"') {
-                RAISE_ERRMSG(ERR_OBJECT_PROPERTY, pystr, idx, JSONDecodeError);
+                raise_errmsg_impl(ERR_OBJECT_PROPERTY, pystr, idx, _st);
                 goto bail;
             }
-            key = SCANSTRING_UNICODE(pystr, idx + 1, s->strict, &next_idx, JSON_EmptyUnicode, JSONDecodeError);
+            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx, _st);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1709,7 +1685,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                whitespace */
             while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
             if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
-                RAISE_ERRMSG(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, JSONDecodeError);
+                raise_errmsg_impl(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, _st);
                 goto bail;
             }
             idx++;
@@ -1751,7 +1727,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                RAISE_ERRMSG(ERR_OBJECT_DELIMITER, pystr, idx, JSONDecodeError);
+                raise_errmsg_impl(ERR_OBJECT_DELIMITER, pystr, idx, _st);
                 goto bail;
             }
             idx++;
@@ -1761,7 +1737,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            RAISE_ERRMSG(ERR_OBJECT_PROPERTY, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_OBJECT_PROPERTY, pystr, idx, _st);
             goto bail;
         }
     }
@@ -1769,9 +1745,9 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
         if (did_parse) {
-            RAISE_ERRMSG(ERR_OBJECT_DELIMITER, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_OBJECT_DELIMITER, pystr, idx, _st);
         } else {
-            RAISE_ERRMSG(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, _st);
         }
         goto bail;
     }
@@ -1897,7 +1873,6 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     Returns a new PyList
     */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSONDecodeError = _st->JSONDecodeError;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -1936,7 +1911,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                RAISE_ERRMSG(ERR_ARRAY_DELIMITER, pystr, idx, JSONDecodeError);
+                raise_errmsg_impl(ERR_ARRAY_DELIMITER, pystr, idx, _st);
                 goto bail;
             }
             idx++;
@@ -1946,7 +1921,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx, _st);
             goto bail;
         }
     }
@@ -1954,9 +1929,9 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
         if (PyList_GET_SIZE(rval)) {
-            RAISE_ERRMSG(ERR_ARRAY_DELIMITER, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_ARRAY_DELIMITER, pystr, idx, _st);
         } else {
-            RAISE_ERRMSG(ERR_ARRAY_VALUE_FIRST, pystr, idx, JSONDecodeError);
+            raise_errmsg_impl(ERR_ARRAY_VALUE_FIRST, pystr, idx, _st);
         }
         goto bail;
     }
@@ -1980,11 +1955,10 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
 
     Returns the result of parse_constant
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSONDecodeError = _st->JSONDecodeError;
     PyObject *rval;
     if (s->parse_constant == Py_None) {
-        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
+        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx,
+                          get_speedups_state(s->module_ref));
         return NULL;
     }
 
@@ -2116,7 +2090,6 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
         May return other types if parse_int or parse_float are set
     */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSONDecodeError = _st->JSONDecodeError;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -2129,7 +2102,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     /* read a sign if it's there, make sure it's not the end of the string */
     if (PyUnicode_READ(kind, str, idx) == '-') {
         if (idx >= end_idx) {
-            RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, start, JSONDecodeError);
+            raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, start, _st);
             return NULL;
         }
         idx++;
@@ -2149,7 +2122,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     }
     else {
         /* no integer digits, error */
-        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, start, JSONDecodeError);
+        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, start, _st);
         return NULL;
     }
 
@@ -2228,9 +2201,6 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
     Returns a new PyObject representation of the term.
     */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_NaN = _st->JSON_NaN;
-    PyObject *JSON_Infinity = _st->JSON_Infinity;
-    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t length = PyString_GET_SIZE(pystr);
     PyObject *rval = NULL;
@@ -2296,7 +2266,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case 'N':
             /* NaN */
             if ((idx + 2 < length) && str[idx + 1] == 'a' && str[idx + 2] == 'N') {
-                rval = _parse_constant(s, pystr, JSON_NaN, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_NaN, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2304,7 +2274,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case 'I':
             /* Infinity */
             if ((idx + 7 < length) && str[idx + 1] == 'n' && str[idx + 2] == 'f' && str[idx + 3] == 'i' && str[idx + 4] == 'n' && str[idx + 5] == 'i' && str[idx + 6] == 't' && str[idx + 7] == 'y') {
-                rval = _parse_constant(s, pystr, JSON_Infinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_Infinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2312,7 +2282,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case '-':
             /* -Infinity */
             if ((idx + 8 < length) && str[idx + 1] == 'I' && str[idx + 2] == 'n' && str[idx + 3] == 'f' && str[idx + 4] == 'i' && str[idx + 5] == 'n' && str[idx + 6] == 'i' && str[idx + 7] == 't' && str[idx + 8] == 'y') {
-                rval = _parse_constant(s, pystr, JSON_NegInfinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_NegInfinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2339,26 +2309,20 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
     Returns a new PyObject representation of the term.
     */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_NaN = _st->JSON_NaN;
-    PyObject *JSON_Infinity = _st->JSON_Infinity;
-    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
-    PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
-    PyObject *JSONDecodeError = _st->JSONDecodeError;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t length = PyUnicode_GET_LENGTH(pystr);
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
+        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx, _st);
         return NULL;
     }
     switch (PyUnicode_READ(kind, str, idx)) {
         case '"':
             /* string */
-            rval = SCANSTRING_UNICODE(pystr, idx + 1,
-                s->strict,
-                next_idx_ptr, JSON_EmptyUnicode, JSONDecodeError);
+            rval = scanstring_unicode(pystr, idx + 1, s->strict,
+                                      next_idx_ptr, _st);
             break;
         case '{':
             /* object */
@@ -2421,7 +2385,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             if ((idx + 2 < length) &&
                 PyUnicode_READ(kind, str, idx + 1) == 'a' &&
                 PyUnicode_READ(kind, str, idx + 2) == 'N') {
-                rval = _parse_constant(s, pystr, JSON_NaN, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_NaN, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2436,7 +2400,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 PyUnicode_READ(kind, str, idx + 5) == 'i' &&
                 PyUnicode_READ(kind, str, idx + 6) == 't' &&
                 PyUnicode_READ(kind, str, idx + 7) == 'y') {
-                rval = _parse_constant(s, pystr, JSON_Infinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_Infinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2452,7 +2416,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 PyUnicode_READ(kind, str, idx + 6) == 'i' &&
                 PyUnicode_READ(kind, str, idx + 7) == 't' &&
                 PyUnicode_READ(kind, str, idx + 8) == 'y') {
-                rval = _parse_constant(s, pystr, JSON_NegInfinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, _st->JSON_NegInfinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2884,20 +2848,20 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-_encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false)
+_encoded_const(PyObject *obj, _speedups_state *state)
 {
     /* Return the JSON string representation of None, True, False */
     if (obj == Py_None) {
-        Py_INCREF(JSON_s_null);
-        return JSON_s_null;
+        Py_INCREF(state->JSON_s_null);
+        return state->JSON_s_null;
     }
     else if (obj == Py_True) {
-        Py_INCREF(JSON_s_true);
-        return JSON_s_true;
+        Py_INCREF(state->JSON_s_true);
+        return state->JSON_s_true;
     }
     else if (obj == Py_False) {
-        Py_INCREF(JSON_s_false);
-        return JSON_s_false;
+        Py_INCREF(state->JSON_s_false);
+        return state->JSON_s_false;
     }
     else {
         PyErr_SetString(PyExc_ValueError, "not a const");
@@ -2910,12 +2874,6 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a PyFloat */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_Infinity = _st->JSON_Infinity;
-    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
-    PyObject *JSON_NaN = _st->JSON_NaN;
-    PyObject *JSON_s_null = _st->JSON_s_null;
-    PyObject *JSON_s_true = _st->JSON_s_true;
-    PyObject *JSON_s_false = _st->JSON_s_false;
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         if (!s->allow_or_ignore_nan) {
@@ -2923,20 +2881,20 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
             return NULL;
         }
         if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
-            return ENCODED_CONST(Py_None, JSON_s_null, JSON_s_true, JSON_s_false);
+            return _encoded_const(Py_None, _st);
         }
         /* JSON_ALLOW_NAN is set */
         else if (i > 0) {
-            Py_INCREF(JSON_Infinity);
-            return JSON_Infinity;
+            Py_INCREF(_st->JSON_Infinity);
+            return _st->JSON_Infinity;
         }
         else if (i < 0) {
-            Py_INCREF(JSON_NegInfinity);
-            return JSON_NegInfinity;
+            Py_INCREF(_st->JSON_NegInfinity);
+            return _st->JSON_NegInfinity;
         }
         else {
-            Py_INCREF(JSON_NaN);
-            return JSON_NaN;
+            Py_INCREF(_st->JSON_NaN);
+            return _st->JSON_NaN;
         }
     }
     /* Use a better float format here? */
@@ -2995,15 +2953,11 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
 {
     /* Encode Python object obj to a JSON term, rval is a PyList */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_s_null = _st->JSON_s_null;
-    PyObject *JSON_s_true = _st->JSON_s_true;
-    PyObject *JSON_s_false = _st->JSON_s_false;
-    PyObject *RawJSONType = _st->RawJSONType;
     int rv = -1;
     do {
         PyObject *newobj;
         if (obj == Py_None || obj == Py_True || obj == Py_False) {
-            PyObject *cstr = ENCODED_CONST(obj, JSON_s_null, JSON_s_true, JSON_s_false);
+            PyObject *cstr = _encoded_const(obj, _st);
             if (cstr != NULL)
                 rv = _steal_accumulate(rval, cstr);
         }
@@ -3093,7 +3047,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 rv = _steal_accumulate(rval, encoded);
         }
         else {
-            int raw = IS_RAW_JSON(obj, RawJSONType);
+            int raw = is_raw_json(obj, _st);
             if (raw < 0)
                 break;
             if (raw) {
@@ -3168,9 +3122,6 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
 {
     /* Encode Python dict dct a JSON term */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_empty_dict = _st->JSON_empty_dict;
-    PyObject *JSON_open_dict = _st->JSON_open_dict;
-    PyObject *JSON_close_dict = _st->JSON_close_dict;
     PyObject *kstr = NULL;
     PyObject *ident = NULL;
     PyObject *iter = NULL;
@@ -3180,7 +3131,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
     Py_ssize_t idx;
 
     if (PyDict_Size(dct) == 0)
-        return JSON_Accu_Accumulate(rval, JSON_empty_dict);
+        return JSON_Accu_Accumulate(rval, _st->JSON_empty_dict);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3198,7 +3149,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
         }
     }
 
-    if (JSON_Accu_Accumulate(rval, JSON_open_dict))
+    if (JSON_Accu_Accumulate(rval, _st->JSON_open_dict))
         goto bail;
 
     if (s->indent != Py_None) {
@@ -3287,7 +3238,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, JSON_close_dict))
+    if (JSON_Accu_Accumulate(rval, _st->JSON_close_dict))
         goto bail;
     return 0;
 
@@ -3307,9 +3258,6 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
 {
     /* Encode Python list seq to a JSON term */
     _speedups_state *_st = get_speedups_state(s->module_ref);
-    PyObject *JSON_empty_array = _st->JSON_empty_array;
-    PyObject *JSON_open_array = _st->JSON_open_array;
-    PyObject *JSON_close_array = _st->JSON_close_array;
     PyObject *ident = NULL;
     PyObject *iter = NULL;
     PyObject *obj = NULL;
@@ -3321,7 +3269,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (is_true == -1)
         return -1;
     else if (is_true == 0)
-        return JSON_Accu_Accumulate(rval, JSON_empty_array);
+        return JSON_Accu_Accumulate(rval, _st->JSON_empty_array);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3343,7 +3291,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (iter == NULL)
         goto bail;
 
-    if (JSON_Accu_Accumulate(rval, JSON_open_array))
+    if (JSON_Accu_Accumulate(rval, _st->JSON_open_array))
         goto bail;
     if (s->indent != Py_None) {
         /* TODO: DOES NOT RUN */
@@ -3379,7 +3327,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, JSON_close_array))
+    if (JSON_Accu_Accumulate(rval, _st->JSON_close_array))
         goto bail;
     return 0;
 

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -37,10 +37,10 @@
 
 #if PY_VERSION_HEX < 0x03090000
 #if !defined(PyObject_CallNoArgs)
-#define PyObject_CallNoArgs(callable) PyObject_CallFunctionObjArgs(callable, NULL);
+#define PyObject_CallNoArgs(callable) PyObject_CallFunctionObjArgs(callable, NULL)
 #endif
 #if !defined(PyObject_CallOneArg)
-#define PyObject_CallOneArg(callable, arg) PyObject_CallFunctionObjArgs(callable, arg, NULL);
+#define PyObject_CallOneArg(callable, arg) PyObject_CallFunctionObjArgs(callable, arg, NULL)
 #endif
 #endif /* PY_VERSION_HEX < 0x03090000 */
 
@@ -119,6 +119,14 @@ typedef struct {
     PyObject *JSON_empty_array;
     PyObject *JSON_sortargs;
     PyObject *JSON_itemgetter0;
+    /* Interned attribute-name strings used in hot paths. Caching them
+     * here lets the scanner/encoder use PyObject_GetAttr (which takes
+     * a PyObject *) instead of PyObject_GetAttrString (which interns
+     * the C string every call). */
+    PyObject *JSON_attr_for_json;     /* "for_json" */
+    PyObject *JSON_attr_asdict;       /* "_asdict" */
+    PyObject *JSON_attr_sort;         /* "sort" */
+    PyObject *JSON_attr_encoded_json; /* "encoded_json" */
     PyObject *RawJSONType;
     PyObject *JSONDecodeError;
 } _speedups_state;
@@ -130,15 +138,22 @@ static struct PyModuleDef moduledef;
 /* Pre-3.13: a single static state instance serves the whole process,
    and a borrowed reference to the module object so that Scanner and
    Encoder instances can store module_ref uniformly. The module object
-   is kept alive by sys.modules for the entire interpreter lifetime. */
+   is kept alive by sys.modules for the entire interpreter lifetime.
+   PyScannerType and PyEncoderType are defined later in this file
+   (the full PyTypeObject bodies); their addresses are cached in
+   _speedups_static_state.{PyScannerType,PyEncoderType} by
+   module_exec, so the PyScanner_Check / PyEncoder_Check macros don't
+   need a forward declaration of those symbols. */
 static _speedups_state _speedups_static_state;
 static PyObject *_speedups_module = NULL;  /* borrowed */
-static PyTypeObject PyScannerType;
-static PyTypeObject PyEncoderType;
-#define PyScanner_Check(op) PyObject_TypeCheck(op, &PyScannerType)
-#define PyScanner_CheckExact(op) (Py_TYPE(op) == &PyScannerType)
-#define PyEncoder_Check(op) PyObject_TypeCheck(op, &PyEncoderType)
-#define PyEncoder_CheckExact(op) (Py_TYPE(op) == &PyEncoderType)
+#define PyScanner_Check(op) \
+    PyObject_TypeCheck(op, (PyTypeObject *)_speedups_static_state.PyScannerType)
+#define PyScanner_CheckExact(op) \
+    (Py_TYPE(op) == (PyTypeObject *)_speedups_static_state.PyScannerType)
+#define PyEncoder_Check(op) \
+    PyObject_TypeCheck(op, (PyTypeObject *)_speedups_static_state.PyEncoderType)
+#define PyEncoder_CheckExact(op) \
+    (Py_TYPE(op) == (PyTypeObject *)_speedups_static_state.PyEncoderType)
 #endif
 
 static inline _speedups_state *
@@ -150,9 +165,14 @@ get_speedups_state(PyObject *module)
      * uninitialized instance leaks into the hot path. */
     assert(module != NULL);
 #if PY_VERSION_HEX >= 0x030D0000
-    void *state = PyModule_GetState(module);
-    assert(state != NULL);
-    return (_speedups_state *)state;
+    {
+        /* Wrapped in an inner block so `state` is declared at the top
+         * of a scope, keeping the file C89-clean under
+         * -Wdeclaration-after-statement. */
+        void *state = PyModule_GetState(module);
+        assert(state != NULL);
+        return (_speedups_state *)state;
+    }
 #else
     (void)module;
     return &_speedups_static_state;
@@ -187,8 +207,6 @@ JSON_Accu_Destroy(JSON_Accu *acc);
 #define ERR_STRING_CONTROL "Invalid control character %r at"
 #define ERR_STRING_ESC1 "Invalid \\X escape sequence %r"
 #define ERR_STRING_ESC4 "Invalid \\uXXXX escape sequence"
-#define FOR_JSON_METHOD_NAME "for_json"
-#define ASDICT_METHOD_NAME "_asdict"
 
 
 typedef struct _PyScannerObject {
@@ -330,7 +348,7 @@ _convertPyInt_AsSsize_t(PyObject *o, Py_ssize_t *size_ptr);
 static PyObject *
 _convertPyInt_FromSsize_t(Py_ssize_t *size_ptr);
 static int
-_call_json_method(PyObject *obj, const char *method_name, PyObject **result);
+_call_json_method(PyObject *obj, PyObject *method_name, PyObject **result);
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
 static int
@@ -454,12 +472,13 @@ static PyObject *
 maybe_quote_bigint(PyEncoderObject* s, PyObject *encoded, PyObject *obj)
 {
     if (s->max_long_size != Py_None && s->min_long_size != Py_None) {
-        int ge = PyObject_RichCompareBool(obj, s->max_long_size, Py_GE);
+        int ge, le;
+        ge = PyObject_RichCompareBool(obj, s->max_long_size, Py_GE);
         if (ge < 0) {
             Py_DECREF(encoded);
             return NULL;
         }
-        int le = PyObject_RichCompareBool(obj, s->min_long_size, Py_LE);
+        le = PyObject_RichCompareBool(obj, s->min_long_size, Py_LE);
         if (le < 0) {
             Py_DECREF(encoded);
             return NULL;
@@ -480,10 +499,13 @@ maybe_quote_bigint(PyEncoderObject* s, PyObject *encoded, PyObject *obj)
 }
 
 static int
-_call_json_method(PyObject *obj, const char *method_name, PyObject **result)
+_call_json_method(PyObject *obj, PyObject *method_name, PyObject **result)
 {
     int rval = 0;
-    PyObject *method = PyObject_GetAttrString(obj, method_name);
+    /* method_name is an interned PyObject string cached in module state
+     * (state->JSON_attr_for_json or state->JSON_attr_asdict), so this
+     * avoids the char-to-interned-unicode conversion on every call. */
+    PyObject *method = PyObject_GetAttr(obj, method_name);
     if (method == NULL) {
         PyErr_Clear();
         return 0;
@@ -493,8 +515,8 @@ _call_json_method(PyObject *obj, const char *method_name, PyObject **result)
         if (tmp == NULL && PyErr_ExceptionMatches(PyExc_TypeError)) {
             PyErr_Clear();
         } else {
-            // This will set result to NULL if a TypeError occurred,
-            // which must be checked by the caller
+            /* This will set result to NULL if a TypeError occurred,
+             * which must be checked by the caller */
             *result = tmp;
             rval = 1;
         }
@@ -828,7 +850,7 @@ encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
     Py_CLEAR(iter);
     if (PyErr_Occurred())
         goto bail;
-    sortfun = PyObject_GetAttrString(lst, "sort");
+    sortfun = PyObject_GetAttr(lst, state->JSON_attr_sort);
     if (sortfun == NULL)
         goto bail;
     sortres = PyObject_Call(sortfun, state->JSON_sortargs, s->item_sort_kw);
@@ -2124,7 +2146,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             if (encoded != NULL)
                 rv = _steal_accumulate(state, rval, encoded);
         }
-        else if (s->for_json && _call_json_method(obj, FOR_JSON_METHOD_NAME, &newobj)) {
+        else if (s->for_json && _call_json_method(obj, state->JSON_attr_for_json, &newobj)) {
             if (newobj == NULL) {
                 return -1;
             }
@@ -2136,7 +2158,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             Py_DECREF(newobj);
             Py_LeaveRecursiveCall();
         }
-        else if (s->namedtuple_as_object && _call_json_method(obj, ASDICT_METHOD_NAME, &newobj)) {
+        else if (s->namedtuple_as_object && _call_json_method(obj, state->JSON_attr_asdict, &newobj)) {
             if (newobj == NULL) {
                 return -1;
             }
@@ -2179,7 +2201,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             if (raw < 0)
                 break;
             if (raw) {
-                PyObject *encoded = PyObject_GetAttrString(obj, "encoded_json");
+                PyObject *encoded = PyObject_GetAttr(obj, state->JSON_attr_encoded_json);
                 if (encoded != NULL)
                     rv = _steal_accumulate(state, rval, encoded);
             }
@@ -2647,6 +2669,10 @@ reset_speedups_state_constants(_speedups_state *state)
     Py_CLEAR(state->JSON_empty_array);
     Py_CLEAR(state->JSON_sortargs);
     Py_CLEAR(state->JSON_itemgetter0);
+    Py_CLEAR(state->JSON_attr_for_json);
+    Py_CLEAR(state->JSON_attr_asdict);
+    Py_CLEAR(state->JSON_attr_sort);
+    Py_CLEAR(state->JSON_attr_encoded_json);
     Py_CLEAR(state->RawJSONType);
     Py_CLEAR(state->JSONDecodeError);
 }
@@ -2732,6 +2758,21 @@ init_speedups_state(_speedups_state *state, PyObject *module)
         if (!state->JSON_itemgetter0)
             return -1;
     }
+
+    /* Interned attribute names used in encoder hot paths. */
+    state->JSON_attr_for_json = JSON_InternFromString("for_json");
+    if (state->JSON_attr_for_json == NULL)
+        return -1;
+    state->JSON_attr_asdict = JSON_InternFromString("_asdict");
+    if (state->JSON_attr_asdict == NULL)
+        return -1;
+    state->JSON_attr_sort = JSON_InternFromString("sort");
+    if (state->JSON_attr_sort == NULL)
+        return -1;
+    state->JSON_attr_encoded_json = JSON_InternFromString("encoded_json");
+    if (state->JSON_attr_encoded_json == NULL)
+        return -1;
+
     (void)module;
     return 0;
 }
@@ -2815,6 +2856,10 @@ speedups_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(state->JSON_empty_array);
     Py_VISIT(state->JSON_sortargs);
     Py_VISIT(state->JSON_itemgetter0);
+    Py_VISIT(state->JSON_attr_for_json);
+    Py_VISIT(state->JSON_attr_asdict);
+    Py_VISIT(state->JSON_attr_sort);
+    Py_VISIT(state->JSON_attr_encoded_json);
     Py_VISIT(state->RawJSONType);
     Py_VISIT(state->JSONDecodeError);
     return 0;

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -106,6 +106,7 @@ typedef struct {
     PyObject *JSON_EmptyUnicode;
 #if PY_MAJOR_VERSION < 3
     PyObject *JSON_EmptyStr;
+    PyObject *JSON_EmptyStr_join;  /* bound method: ''.join */
 #endif
     PyObject *JSON_s_null;
     PyObject *JSON_s_true;
@@ -871,13 +872,7 @@ static PyObject *
 join_list_string(_speedups_state *state, PyObject *lst)
 {
     /* return ''.join(lst) */
-    static PyObject *joinfn = NULL;
-    if (joinfn == NULL) {
-        joinfn = PyObject_GetAttrString(state->JSON_EmptyStr, "join");
-        if (joinfn == NULL)
-            return NULL;
-    }
-    return PyObject_CallOneArg(joinfn, lst);
+    return PyObject_CallOneArg(state->JSON_EmptyStr_join, lst);
 }
 #endif /* PY_MAJOR_VERSION < 3 */
 
@@ -3522,6 +3517,7 @@ reset_speedups_state_constants(_speedups_state *state)
     Py_CLEAR(state->JSON_EmptyUnicode);
 #if PY_MAJOR_VERSION < 3
     Py_CLEAR(state->JSON_EmptyStr);
+    Py_CLEAR(state->JSON_EmptyStr_join);
 #endif
     Py_CLEAR(state->JSON_s_null);
     Py_CLEAR(state->JSON_s_true);
@@ -3564,6 +3560,9 @@ init_speedups_state(_speedups_state *state, PyObject *module)
 #else
     state->JSON_EmptyStr = PyString_FromString("");
     if (state->JSON_EmptyStr == NULL)
+        return -1;
+    state->JSON_EmptyStr_join = PyObject_GetAttrString(state->JSON_EmptyStr, "join");
+    if (state->JSON_EmptyStr_join == NULL)
         return -1;
     state->JSON_EmptyUnicode = PyUnicode_FromUnicode(NULL, 0);
 #endif

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -302,7 +302,7 @@ static PyObject *
 scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
 scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
-               char *encoding, int strict, Py_ssize_t *next_end_ptr);
+               const char *encoding, int strict, Py_ssize_t *next_end_ptr);
 static PyObject *
 _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 #endif
@@ -338,7 +338,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
 static PyObject *
 _encoded_const(_speedups_state *state, PyObject *obj);
 static void
-raise_errmsg(_speedups_state *state, char *msg, PyObject *s, Py_ssize_t end);
+raise_errmsg(_speedups_state *state, const char *msg, PyObject *s, Py_ssize_t end);
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -348,11 +348,13 @@ _convertPyInt_FromSsize_t(Py_ssize_t *size_ptr);
 static int
 _call_json_method(PyObject *obj, PyObject *method_name, PyObject **result);
 static PyObject *
+encoder_long_to_str(PyObject *obj);
+static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
 static int
 init_speedups_state(_speedups_state *state, PyObject *module);
 static PyObject *
-import_dependency(char *module_name, char *attr_name);
+import_dependency(const char *module_name, const char *attr_name);
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
@@ -500,6 +502,24 @@ maybe_quote_bigint(PyEncoderObject* s, PyObject *encoded, PyObject *obj)
 #endif
     Py_DECREF(encoded);
     return quoted;
+}
+
+/* Stringify an int/long to its JSON decimal form. For int/long subclasses
+ * we first normalize through PyLong_Type so custom __str__ / __repr__
+ * overrides don't inject garbage into the JSON output (see #118). */
+static PyObject *
+encoder_long_to_str(PyObject *obj)
+{
+    PyObject *encoded;
+    PyObject *tmp;
+    if (PyInt_CheckExact(obj) || PyLong_CheckExact(obj))
+        return PyObject_Str(obj);
+    tmp = PyObject_CallOneArg((PyObject *)&PyLong_Type, obj);
+    if (tmp == NULL)
+        return NULL;
+    encoded = PyObject_Str(tmp);
+    Py_DECREF(tmp);
+    return encoded;
 }
 
 static int
@@ -755,20 +775,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
         return _encoded_const(state, key);
     }
     else if (PyInt_Check(key) || PyLong_Check(key)) {
-        if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
-            /* See #118, do not trust custom str/repr */
-            PyObject *res;
-            PyObject *tmp = PyObject_CallOneArg((PyObject *)&PyLong_Type, key);
-            if (tmp == NULL) {
-                return NULL;
-            }
-            res = PyObject_Str(tmp);
-            Py_DECREF(tmp);
-            return res;
-        }
-        else {
-            return PyObject_Str(key);
-        }
+        return encoder_long_to_str(key);
     }
     else if (s->use_decimal && PyObject_TypeCheck(key, (PyTypeObject *)s->Decimal)) {
         return PyObject_Str(key);
@@ -876,7 +883,7 @@ bail:
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
 static void
-raise_errmsg(_speedups_state *state, char *msg, PyObject *s, Py_ssize_t end)
+raise_errmsg(_speedups_state *state, const char *msg, PyObject *s, Py_ssize_t end)
 {
     PyObject *JSONDecodeError = state->JSONDecodeError;
     PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
@@ -948,7 +955,7 @@ _build_rval_index_tuple(PyObject *rval, Py_ssize_t idx)
 #if PY_MAJOR_VERSION < 3
 static PyObject *
 scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
-               char *encoding, int strict, Py_ssize_t *next_end_ptr)
+               const char *encoding, int strict, Py_ssize_t *next_end_ptr)
 {
     /* Read the JSON string from PyString pystr.
     end is the index of the first character after the quote.
@@ -2193,21 +2200,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 rv = _steal_accumulate(state, rval, encoded);
         }
         else if (PyInt_Check(obj) || PyLong_Check(obj)) {
-            PyObject *encoded;
-            if (PyInt_CheckExact(obj) || PyLong_CheckExact(obj)) {
-                encoded = PyObject_Str(obj);
-            }
-            else {
-                /* See #118, do not trust custom str/repr */
-                PyObject *tmp = PyObject_CallOneArg((PyObject *)&PyLong_Type, obj);
-                if (tmp == NULL) {
-                    encoded = NULL;
-                }
-                else {
-                    encoded = PyObject_Str(tmp);
-                    Py_DECREF(tmp);
-                }
-            }
+            PyObject *encoded = encoder_long_to_str(obj);
             if (encoded != NULL) {
                 encoded = maybe_quote_bigint(s, encoded, obj);
                 if (encoded == NULL)
@@ -2322,7 +2315,6 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
     PyObject *ident = NULL;
     PyObject *iter = NULL;
     PyObject *item = NULL;
-    PyObject *items = NULL;
     PyObject *encoded = NULL;
     Py_ssize_t idx;
 
@@ -2347,16 +2339,6 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
 
     if (JSON_Accu_Accumulate(state, rval, state->JSON_open_dict))
         goto bail;
-
-    if (s->indent != Py_None) {
-        /* TODO: DOES NOT RUN */
-        indent_level += 1;
-        /*
-            newline_indent = '\n' + (_indent * _current_indent_level)
-            separator = _item_separator + newline_indent
-            buf += newline_indent
-        */
-    }
 
     iter = encoder_dict_iteritems(s, dct);
     if (iter == NULL)
@@ -2427,20 +2409,12 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             goto bail;
         Py_CLEAR(ident);
     }
-    if (s->indent != Py_None) {
-        /* TODO: DOES NOT RUN */
-        indent_level -= 1;
-        /*
-            yield '\n' + (_indent * _current_indent_level)
-        */
-    }
     if (JSON_Accu_Accumulate(state, rval, state->JSON_close_dict))
         goto bail;
     return 0;
 
 bail:
     Py_XDECREF(encoded);
-    Py_XDECREF(items);
     Py_XDECREF(item);
     Py_XDECREF(iter);
     Py_XDECREF(kstr);
@@ -2460,7 +2434,6 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     int is_true;
     int i = 0;
 
-    ident = NULL;
     is_true = PyObject_IsTrue(seq);
     if (is_true == -1)
         return -1;
@@ -2489,15 +2462,6 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
 
     if (JSON_Accu_Accumulate(state, rval, state->JSON_open_array))
         goto bail;
-    if (s->indent != Py_None) {
-        /* TODO: DOES NOT RUN */
-        indent_level += 1;
-        /*
-            newline_indent = '\n' + (_indent * _current_indent_level)
-            separator = _item_separator + newline_indent
-            buf += newline_indent
-        */
-    }
     while ((obj = PyIter_Next(iter))) {
         if (i) {
             if (JSON_Accu_Accumulate(state, rval, s->item_separator))
@@ -2515,13 +2479,6 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
         if (PyDict_DelItem(s->markers, ident))
             goto bail;
         Py_CLEAR(ident);
-    }
-    if (s->indent != Py_None) {
-        /* TODO: DOES NOT RUN */
-        indent_level -= 1;
-        /*
-            yield '\n' + (_indent * _current_indent_level)
-        */
     }
     if (JSON_Accu_Accumulate(state, rval, state->JSON_close_array))
         goto bail;
@@ -2959,7 +2916,7 @@ static struct PyModuleDef moduledef = {
 #endif
 
 static PyObject *
-import_dependency(char *module_name, char *attr_name)
+import_dependency(const char *module_name, const char *attr_name)
 {
     PyObject *rval;
     PyObject *module = PyImport_ImportModule(module_name);

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1447,514 +1447,13 @@ scanner_clear(PyObject *self)
     return 0;
 }
 
-#if PY_MAJOR_VERSION < 3
 static PyObject *
-_parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+_parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant,
+                Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
 {
-    /* Read a JSON object from PyString pystr.
-    idx is the index of the first character after the opening curly brace.
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the closing curly brace.
-
-    Returns a new PyObject (usually a dict, but object_hook or
-    object_pairs_hook can change that)
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    char *str = PyString_AS_STRING(pystr);
-    Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
-    PyObject *rval = NULL;
-    PyObject *pairs = NULL;
-    PyObject *item;
-    PyObject *key = NULL;
-    PyObject *val = NULL;
-    char *encoding = PyString_AS_STRING(s->encoding);
-    int has_pairs_hook = (s->pairs_hook != Py_None);
-    int did_parse = 0;
-    Py_ssize_t next_idx;
-    if (has_pairs_hook) {
-        pairs = PyList_New(0);
-        if (pairs == NULL)
-            return NULL;
-    }
-    else {
-        rval = PyDict_New();
-        if (rval == NULL)
-            return NULL;
-    }
-
-    /* skip whitespace after { */
-    while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-
-    /* only loop if the object is non-empty */
-    if (idx <= end_idx && str[idx] != '}') {
-        int trailing_delimiter = 0;
-        while (idx <= end_idx) {
-            PyObject *memokey;
-            trailing_delimiter = 0;
-
-            /* read key */
-            if (str[idx] != '"') {
-                raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
-                goto bail;
-            }
-            key = scanstring_str(state, pystr, idx + 1, encoding, s->strict, &next_idx);
-            if (key == NULL)
-                goto bail;
-            memokey = PyDict_GetItemWithError(s->memo, key);
-            if (memokey != NULL) {
-                Py_INCREF(memokey);
-                Py_DECREF(key);
-                key = memokey;
-            }
-            else if (PyErr_Occurred()) {
-                goto bail;
-            }
-            else {
-                if (PyDict_SetItem(s->memo, key, key) < 0)
-                    goto bail;
-            }
-            idx = next_idx;
-
-            /* skip whitespace between key and : delimiter, read :, skip whitespace */
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-            if (idx > end_idx || str[idx] != ':') {
-                raise_errmsg(state, ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-
-            /* read any JSON data type */
-            val = scan_once_str(s, pystr, idx, &next_idx);
-            if (val == NULL)
-                goto bail;
-
-            if (has_pairs_hook) {
-                item = PyTuple_Pack(2, key, val);
-                if (item == NULL)
-                    goto bail;
-                Py_CLEAR(key);
-                Py_CLEAR(val);
-                if (PyList_Append(pairs, item) == -1) {
-                    Py_DECREF(item);
-                    goto bail;
-                }
-                Py_DECREF(item);
-            }
-            else {
-                if (PyDict_SetItem(rval, key, val) < 0)
-                    goto bail;
-                Py_CLEAR(key);
-                Py_CLEAR(val);
-            }
-            idx = next_idx;
-
-            /* skip whitespace before } or , */
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-
-            /* bail if the object is closed or we didn't get the , delimiter */
-            did_parse = 1;
-            if (idx > end_idx) break;
-            if (str[idx] == '}') {
-                break;
-            }
-            else if (str[idx] != ',') {
-                raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-
-            /* skip whitespace after , delimiter */
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-            trailing_delimiter = 1;
-        }
-        if (trailing_delimiter) {
-            raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
-            goto bail;
-        }
-    }
-    /* verify that idx < end_idx, str[idx] should be '}' */
-    if (idx > end_idx || str[idx] != '}') {
-        if (did_parse) {
-            raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
-        } else {
-            raise_errmsg(state, ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
-        }
-        goto bail;
-    }
-
-    /* if pairs_hook is not None: rval = object_pairs_hook(pairs) */
-    if (s->pairs_hook != Py_None) {
-        val = PyObject_CallOneArg(s->pairs_hook, pairs);
-        if (val == NULL)
-            goto bail;
-        Py_DECREF(pairs);
-        *next_idx_ptr = idx + 1;
-        return val;
-    }
-
-    /* if object_hook is not None: rval = object_hook(rval) */
-    if (s->object_hook != Py_None) {
-        val = PyObject_CallOneArg(s->object_hook, rval);
-        if (val == NULL)
-            goto bail;
-        Py_DECREF(rval);
-        rval = val;
-        val = NULL;
-    }
-    *next_idx_ptr = idx + 1;
-    return rval;
-bail:
-    Py_XDECREF(rval);
-    Py_XDECREF(key);
-    Py_XDECREF(val);
-    Py_XDECREF(pairs);
-    return NULL;
-}
-#endif /* PY_MAJOR_VERSION < 3 */
-
-static PyObject *
-_parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
-{
-    /* Read a JSON object from PyUnicode pystr.
-    idx is the index of the first character after the opening curly brace.
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the closing curly brace.
-
-    Returns a new PyObject (usually a dict, but object_hook can change that)
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    void *str = PyUnicode_DATA(pystr);
-    Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
-    PY2_UNUSED int kind = PyUnicode_KIND(pystr);
-    PyObject *rval = NULL;
-    PyObject *pairs = NULL;
-    PyObject *item;
-    PyObject *key = NULL;
-    PyObject *val = NULL;
-    int has_pairs_hook = (s->pairs_hook != Py_None);
-    int did_parse = 0;
-    Py_ssize_t next_idx;
-
-    if (has_pairs_hook) {
-        pairs = PyList_New(0);
-        if (pairs == NULL)
-            return NULL;
-    }
-    else {
-        rval = PyDict_New();
-        if (rval == NULL)
-            return NULL;
-    }
-
-    /* skip whitespace after { */
-    while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-
-    /* only loop if the object is non-empty */
-    if (idx <= end_idx && PyUnicode_READ(kind, str, idx) != '}') {
-        int trailing_delimiter = 0;
-        while (idx <= end_idx) {
-            PyObject *memokey;
-            trailing_delimiter = 0;
-
-            /* read key */
-            if (PyUnicode_READ(kind, str, idx) != '"') {
-                raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
-                goto bail;
-            }
-            key = scanstring_unicode(state, pystr, idx + 1, s->strict, &next_idx);
-            if (key == NULL)
-                goto bail;
-            memokey = PyDict_GetItemWithError(s->memo, key);
-            if (memokey != NULL) {
-                Py_INCREF(memokey);
-                Py_DECREF(key);
-                key = memokey;
-            }
-            else if (PyErr_Occurred()) {
-                goto bail;
-            }
-            else {
-                if (PyDict_SetItem(s->memo, key, key) < 0)
-                    goto bail;
-            }
-            idx = next_idx;
-
-            /* skip whitespace between key and : delimiter, read :, skip
-               whitespace */
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-            if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
-                raise_errmsg(state, ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-
-            /* read any JSON term */
-            val = scan_once_unicode(s, pystr, idx, &next_idx);
-            if (val == NULL)
-                goto bail;
-
-            if (has_pairs_hook) {
-                item = PyTuple_Pack(2, key, val);
-                if (item == NULL)
-                    goto bail;
-                Py_CLEAR(key);
-                Py_CLEAR(val);
-                if (PyList_Append(pairs, item) == -1) {
-                    Py_DECREF(item);
-                    goto bail;
-                }
-                Py_DECREF(item);
-            }
-            else {
-                if (PyDict_SetItem(rval, key, val) < 0)
-                    goto bail;
-                Py_CLEAR(key);
-                Py_CLEAR(val);
-            }
-            idx = next_idx;
-
-            /* skip whitespace before } or , */
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-
-            /* bail if the object is closed or we didn't get the ,
-               delimiter */
-            did_parse = 1;
-            if (idx > end_idx) break;
-            if (PyUnicode_READ(kind, str, idx) == '}') {
-                break;
-            }
-            else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-
-            /* skip whitespace after , delimiter */
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-            trailing_delimiter = 1;
-        }
-        if (trailing_delimiter) {
-            raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
-            goto bail;
-        }
-    }
-
-    /* verify that idx < end_idx, str[idx] should be '}' */
-    if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
-        if (did_parse) {
-            raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
-        } else {
-            raise_errmsg(state, ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
-        }
-        goto bail;
-    }
-
-    /* if pairs_hook is not None: rval = object_pairs_hook(pairs) */
-    if (s->pairs_hook != Py_None) {
-        val = PyObject_CallOneArg(s->pairs_hook, pairs);
-        if (val == NULL)
-            goto bail;
-        Py_DECREF(pairs);
-        *next_idx_ptr = idx + 1;
-        return val;
-    }
-
-    /* if object_hook is not None: rval = object_hook(rval) */
-    if (s->object_hook != Py_None) {
-        val = PyObject_CallOneArg(s->object_hook, rval);
-        if (val == NULL)
-            goto bail;
-        Py_DECREF(rval);
-        rval = val;
-        val = NULL;
-    }
-    *next_idx_ptr = idx + 1;
-    return rval;
-bail:
-    Py_XDECREF(rval);
-    Py_XDECREF(key);
-    Py_XDECREF(val);
-    Py_XDECREF(pairs);
-    return NULL;
-}
-
-#if PY_MAJOR_VERSION < 3
-static PyObject *
-_parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
-{
-    /* Read a JSON array from PyString pystr.
-    idx is the index of the first character after the opening brace.
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the closing brace.
-
-    Returns a new PyList
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    char *str = PyString_AS_STRING(pystr);
-    Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
-    PyObject *val = NULL;
-    PyObject *rval = PyList_New(0);
-    Py_ssize_t next_idx;
-    if (rval == NULL)
-        return NULL;
-
-    /* skip whitespace after [ */
-    while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-
-    /* only loop if the array is non-empty */
-    if (idx <= end_idx && str[idx] != ']') {
-        int trailing_delimiter = 0;
-        while (idx <= end_idx) {
-            trailing_delimiter = 0;
-            /* read any JSON term and de-tuplefy the (rval, idx) */
-            val = scan_once_str(s, pystr, idx, &next_idx);
-            if (val == NULL) {
-                goto bail;
-            }
-
-            if (PyList_Append(rval, val) == -1)
-                goto bail;
-
-            Py_CLEAR(val);
-            idx = next_idx;
-
-            /* skip whitespace between term and , */
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-
-            /* bail if the array is closed or we didn't get the , delimiter */
-            if (idx > end_idx) break;
-            if (str[idx] == ']') {
-                break;
-            }
-            else if (str[idx] != ',') {
-                raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-
-            /* skip whitespace after , */
-            while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
-            trailing_delimiter = 1;
-        }
-        if (trailing_delimiter) {
-            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
-            goto bail;
-        }
-    }
-
-    /* verify that idx < end_idx, str[idx] should be ']' */
-    if (idx > end_idx || str[idx] != ']') {
-        if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
-        } else {
-            raise_errmsg(state, ERR_ARRAY_VALUE_FIRST, pystr, idx);
-        }
-        goto bail;
-    }
-    *next_idx_ptr = idx + 1;
-    return rval;
-bail:
-    Py_XDECREF(val);
-    Py_DECREF(rval);
-    return NULL;
-}
-#endif /* PY_MAJOR_VERSION < 3 */
-
-static PyObject *
-_parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
-{
-    /* Read a JSON array from PyString pystr.
-    idx is the index of the first character after the opening brace.
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the closing brace.
-
-    Returns a new PyList
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    PY2_UNUSED int kind = PyUnicode_KIND(pystr);
-    void *str = PyUnicode_DATA(pystr);
-    Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
-    PyObject *val = NULL;
-    PyObject *rval = PyList_New(0);
-    Py_ssize_t next_idx;
-    if (rval == NULL)
-        return NULL;
-
-    /* skip whitespace after [ */
-    while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-
-    /* only loop if the array is non-empty */
-    if (idx <= end_idx && PyUnicode_READ(kind, str, idx) != ']') {
-        int trailing_delimiter = 0;
-        while (idx <= end_idx) {
-            trailing_delimiter = 0;
-            /* read any JSON term  */
-            val = scan_once_unicode(s, pystr, idx, &next_idx);
-            if (val == NULL) {
-                goto bail;
-            }
-
-            if (PyList_Append(rval, val) == -1)
-                goto bail;
-
-            Py_CLEAR(val);
-            idx = next_idx;
-
-            /* skip whitespace between term and , */
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-
-            /* bail if the array is closed or we didn't get the , delimiter */
-            if (idx > end_idx) break;
-            if (PyUnicode_READ(kind, str, idx) == ']') {
-                break;
-            }
-            else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
-                goto bail;
-            }
-            idx++;
-
-            /* skip whitespace after , */
-            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
-            trailing_delimiter = 1;
-        }
-        if (trailing_delimiter) {
-            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
-            goto bail;
-        }
-    }
-
-    /* verify that idx < end_idx, str[idx] should be ']' */
-    if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
-        if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
-        } else {
-            raise_errmsg(state, ERR_ARRAY_VALUE_FIRST, pystr, idx);
-        }
-        goto bail;
-    }
-    *next_idx_ptr = idx + 1;
-    return rval;
-bail:
-    Py_XDECREF(val);
-    Py_DECREF(rval);
-    return NULL;
-}
-
-static PyObject *
-_parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
-{
-    /* Read a JSON constant from PyString pystr.
-    constant is the Python string that was found
-        ("NaN", "Infinity", "-Infinity").
-    idx is the index of the first character of the constant
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the constant.
-
-    Returns the result of parse_constant
-    */
+    /* Read a JSON constant from pystr. `constant` is the Python string
+       that was found ("NaN", "Infinity", "-Infinity"). Returns the
+       result of s->parse_constant(constant). */
     PyObject *rval;
     if (s->parse_constant == Py_None) {
         raise_errmsg(get_speedups_state(s->module_ref),
@@ -1962,473 +1461,92 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
         return NULL;
     }
 
-    /* rval = parse_constant(constant) */
     rval = PyObject_CallOneArg(s->parse_constant, constant);
     idx += PyString_GET_SIZE(constant);
     *next_idx_ptr = idx;
     return rval;
 }
 
-#if PY_MAJOR_VERSION < 3
-static PyObject *
-_match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssize_t *next_idx_ptr)
+/* -- Helper functions for _match_number fast paths (used by the
+   _speedups_scan.h template). Factored out so the template can stay
+   agnostic about PyFloat / PyInt vs PyObject_CallOneArg details. */
+
+static inline PyObject *
+_match_number_float_fast_unicode(PyObject *numstr)
 {
-    /* Read a JSON number from PyString pystr.
-    idx is the index of the first character of the number
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the number.
-
-    Returns a new PyObject representation of that number:
-        PyInt, PyLong, or PyFloat.
-        May return other types if parse_int or parse_float are set
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    char *str = PyString_AS_STRING(pystr);
-    Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
-    Py_ssize_t idx = start;
-    int is_float = 0;
-    PyObject *rval;
-    PyObject *numstr;
-
-    /* read a sign if it's there, make sure it's not the end of the string */
-    if (str[idx] == '-') {
-        if (idx >= end_idx) {
-            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
-            return NULL;
-        }
-        idx++;
-    }
-
-    /* read as many integer digits as we find as long as it doesn't start with 0 */
-    if (str[idx] >= '1' && str[idx] <= '9') {
-        idx++;
-        while (idx <= end_idx && str[idx] >= '0' && str[idx] <= '9') idx++;
-    }
-    /* if it starts with 0 we only expect one integer digit */
-    else if (str[idx] == '0') {
-        idx++;
-    }
-    /* no integer digits, error */
-    else {
-        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
-        return NULL;
-    }
-
-    /* if the next char is '.' followed by a digit then read all float digits */
-    if (idx < end_idx && str[idx] == '.' && str[idx + 1] >= '0' && str[idx + 1] <= '9') {
-        is_float = 1;
-        idx += 2;
-        while (idx <= end_idx && str[idx] >= '0' && str[idx] <= '9') idx++;
-    }
-
-    /* if the next char is 'e' or 'E' then maybe read the exponent (or backtrack) */
-    if (idx < end_idx && (str[idx] == 'e' || str[idx] == 'E')) {
-
-        /* save the index of the 'e' or 'E' just in case we need to backtrack */
-        Py_ssize_t e_start = idx;
-        idx++;
-
-        /* read an exponent sign if present */
-        if (idx < end_idx && (str[idx] == '-' || str[idx] == '+')) idx++;
-
-        /* read all digits */
-        while (idx <= end_idx && str[idx] >= '0' && str[idx] <= '9') idx++;
-
-        /* if we got a digit, then parse as float. if not, backtrack */
-        if (str[idx - 1] >= '0' && str[idx - 1] <= '9') {
-            is_float = 1;
-        }
-        else {
-            idx = e_start;
-        }
-    }
-
-    /* copy the section we determined to be a number */
-    numstr = PyString_FromStringAndSize(&str[start], idx - start);
-    if (numstr == NULL)
-        return NULL;
-    if (is_float) {
-        /* parse as a float using a fast path if available, otherwise call user defined method */
-        if (s->parse_float != (PyObject *)&PyFloat_Type) {
-            rval = PyObject_CallOneArg(s->parse_float, numstr);
-        }
-        else {
-            /* rval = PyFloat_FromDouble(PyOS_ascii_atof(PyString_AS_STRING(numstr))); */
-            double d = PyOS_string_to_double(PyString_AS_STRING(numstr),
-                                             NULL, NULL);
-            if (d == -1.0 && PyErr_Occurred()) {
-                Py_DECREF(numstr);
-                return NULL;
-            }
-            rval = PyFloat_FromDouble(d);
-        }
-    }
-    else {
-        /* parse as an int using a fast path if available, otherwise call user defined method */
-        if (s->parse_int != (PyObject *)&PyInt_Type) {
-            rval = PyObject_CallOneArg(s->parse_int, numstr);
-        }
-        else {
-            rval = PyInt_FromString(PyString_AS_STRING(numstr), NULL, 10);
-        }
-    }
-    Py_DECREF(numstr);
-    *next_idx_ptr = idx;
-    return rval;
+#if PY_MAJOR_VERSION >= 3
+    return PyFloat_FromString(numstr);
+#else
+    return PyFloat_FromString(numstr, NULL);
+#endif
 }
-#endif /* PY_MAJOR_VERSION < 3 */
 
-static PyObject *
-_match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssize_t *next_idx_ptr)
+static inline PyObject *
+_match_number_int_fast_unicode(PyScannerObject *s, PyObject *numstr)
 {
-    /* Read a JSON number from PyUnicode pystr.
-    idx is the index of the first character of the number
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the number.
-
-    Returns a new PyObject representation of that number:
-        PyInt, PyLong, or PyFloat.
-        May return other types if parse_int or parse_float are set
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    PY2_UNUSED int kind = PyUnicode_KIND(pystr);
-    void *str = PyUnicode_DATA(pystr);
-    Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
-    Py_ssize_t idx = start;
-    int is_float = 0;
-    JSON_UNICHR c;
-    PyObject *rval;
-    PyObject *numstr;
-
-    /* read a sign if it's there, make sure it's not the end of the string */
-    if (PyUnicode_READ(kind, str, idx) == '-') {
-        if (idx >= end_idx) {
-            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
-            return NULL;
-        }
-        idx++;
-    }
-
-    /* read as many integer digits as we find as long as it doesn't start with 0 */
-    c = PyUnicode_READ(kind, str, idx);
-    if (c == '0') {
-        /* if it starts with 0 we only expect one integer digit */
-        idx++;
-    }
-    else if (IS_DIGIT(c)) {
-        idx++;
-        while (idx <= end_idx && IS_DIGIT(PyUnicode_READ(kind, str, idx))) {
-            idx++;
-        }
-    }
-    else {
-        /* no integer digits, error */
-        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
-        return NULL;
-    }
-
-    /* if the next char is '.' followed by a digit then read all float digits */
-    if (idx < end_idx &&
-        PyUnicode_READ(kind, str, idx) == '.' &&
-        IS_DIGIT(PyUnicode_READ(kind, str, idx + 1))) {
-        is_float = 1;
-        idx += 2;
-        while (idx <= end_idx && IS_DIGIT(PyUnicode_READ(kind, str, idx))) idx++;
-    }
-
-    /* if the next char is 'e' or 'E' then maybe read the exponent (or backtrack) */
-    if (idx < end_idx &&
-        (PyUnicode_READ(kind, str, idx) == 'e' ||
-            PyUnicode_READ(kind, str, idx) == 'E')) {
-        Py_ssize_t e_start = idx;
-        idx++;
-
-        /* read an exponent sign if present */
-        if (idx < end_idx &&
-            (PyUnicode_READ(kind, str, idx) == '-' ||
-                PyUnicode_READ(kind, str, idx) == '+')) idx++;
-
-        /* read all digits */
-        while (idx <= end_idx && IS_DIGIT(PyUnicode_READ(kind, str, idx))) idx++;
-
-        /* if we got a digit, then parse as float. if not, backtrack */
-        if (IS_DIGIT(PyUnicode_READ(kind, str, idx - 1))) {
-            is_float = 1;
-        }
-        else {
-            idx = e_start;
-        }
-    }
-
-    /* copy the section we determined to be a number */
-#if PY_MAJOR_VERSION >= 3
-    numstr = PyUnicode_Substring(pystr, start, idx);
-#else
-    numstr = PyUnicode_FromUnicode(&((Py_UNICODE *)str)[start], idx - start);
-#endif
-    if (numstr == NULL)
-        return NULL;
-    if (is_float) {
-        /* parse as a float using a fast path if available, otherwise call user defined method */
-        if (s->parse_float != (PyObject *)&PyFloat_Type) {
-            rval = PyObject_CallOneArg(s->parse_float, numstr);
-        }
-        else {
-#if PY_MAJOR_VERSION >= 3
-            rval = PyFloat_FromString(numstr);
-#else
-            rval = PyFloat_FromString(numstr, NULL);
-#endif
-        }
-    }
-    else {
-        /* no fast path for unicode -> int, just call */
-        rval = PyObject_CallOneArg(s->parse_int, numstr);
-    }
-    Py_DECREF(numstr);
-    *next_idx_ptr = idx;
-    return rval;
+    /* No fast path for unicode -> int; always call parse_int. */
+    return PyObject_CallOneArg(s->parse_int, numstr);
 }
 
 #if PY_MAJOR_VERSION < 3
-static PyObject *
-scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+static inline PyObject *
+_match_number_float_fast_str(PyObject *numstr)
 {
-    /* Read one JSON term (of any kind) from PyString pystr.
-    idx is the index of the first character of the term
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the number.
-
-    Returns a new PyObject representation of the term.
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    char *str = PyString_AS_STRING(pystr);
-    Py_ssize_t length = PyString_GET_SIZE(pystr);
-    PyObject *rval = NULL;
-    int fallthrough = 0;
-    if (idx < 0 || idx >= length) {
-        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
+    double d = PyOS_string_to_double(PyString_AS_STRING(numstr), NULL, NULL);
+    if (d == -1.0 && PyErr_Occurred())
         return NULL;
-    }
-    switch (str[idx]) {
-        case '"':
-            /* string */
-            rval = scanstring_str(state, pystr, idx + 1,
-                                  PyString_AS_STRING(s->encoding),
-                                  s->strict, next_idx_ptr);
-            break;
-        case '{':
-            /* object */
-            if (Py_EnterRecursiveCall(" while decoding a JSON object "
-                                      "from a string"))
-                return NULL;
-            rval = _parse_object_str(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
-            break;
-        case '[':
-            /* array */
-            if (Py_EnterRecursiveCall(" while decoding a JSON array "
-                                      "from a string"))
-                return NULL;
-            rval = _parse_array_str(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
-            break;
-        case 'n':
-            /* null */
-            if ((idx + 3 < length) && str[idx + 1] == 'u' && str[idx + 2] == 'l' && str[idx + 3] == 'l') {
-                Py_INCREF(Py_None);
-                *next_idx_ptr = idx + 4;
-                rval = Py_None;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 't':
-            /* true */
-            if ((idx + 3 < length) && str[idx + 1] == 'r' && str[idx + 2] == 'u' && str[idx + 3] == 'e') {
-                Py_INCREF(Py_True);
-                *next_idx_ptr = idx + 4;
-                rval = Py_True;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'f':
-            /* false */
-            if ((idx + 4 < length) && str[idx + 1] == 'a' && str[idx + 2] == 'l' && str[idx + 3] == 's' && str[idx + 4] == 'e') {
-                Py_INCREF(Py_False);
-                *next_idx_ptr = idx + 5;
-                rval = Py_False;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'N':
-            /* NaN */
-            if ((idx + 2 < length) && str[idx + 1] == 'a' && str[idx + 2] == 'N') {
-                rval = _parse_constant(s, pystr, state->JSON_NaN, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'I':
-            /* Infinity */
-            if ((idx + 7 < length) && str[idx + 1] == 'n' && str[idx + 2] == 'f' && str[idx + 3] == 'i' && str[idx + 4] == 'n' && str[idx + 5] == 'i' && str[idx + 6] == 't' && str[idx + 7] == 'y') {
-                rval = _parse_constant(s, pystr, state->JSON_Infinity, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        case '-':
-            /* -Infinity */
-            if ((idx + 8 < length) && str[idx + 1] == 'I' && str[idx + 2] == 'n' && str[idx + 3] == 'f' && str[idx + 4] == 'i' && str[idx + 5] == 'n' && str[idx + 6] == 'i' && str[idx + 7] == 't' && str[idx + 8] == 'y') {
-                rval = _parse_constant(s, pystr, state->JSON_NegInfinity, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        default:
-            fallthrough = 1;
-    }
-    /* Didn't find a string, object, array, or named constant. Look for a number. */
-    if (fallthrough)
-        rval = _match_number_str(s, pystr, idx, next_idx_ptr);
-    return rval;
+    return PyFloat_FromDouble(d);
 }
+
+static inline PyObject *
+_match_number_int_fast_str(PyScannerObject *s, PyObject *numstr)
+{
+    if (s->parse_int != (PyObject *)&PyInt_Type) {
+        return PyObject_CallOneArg(s->parse_int, numstr);
+    }
+    return PyInt_FromString(PyString_AS_STRING(numstr), NULL, 10);
+}
+#endif
+
+/* -- Generate scan_once_unicode, _parse_object_unicode, _parse_array_unicode,
+   _match_number_unicode from the shared template. -- */
+#define JSON_SCAN_SUFFIX _unicode
+#define JSON_SCAN_DATA_INIT(p) \
+    PY2_UNUSED int kind = PyUnicode_KIND(p); \
+    void *str = PyUnicode_DATA(p); \
+    Py_ssize_t end_idx = PyUnicode_GET_LENGTH(p) - 1
+#define JSON_SCAN_READ(i) PyUnicode_READ(kind, str, (i))
+#define JSON_SCAN_SCANSTRING_CALL(pos, nextp) \
+    scanstring_unicode(state, pystr, (pos), s->strict, (nextp))
+#if PY_MAJOR_VERSION >= 3
+#define JSON_SCAN_NUMSTR_CREATE(sidx, eidx) \
+    PyUnicode_Substring(pystr, (sidx), (eidx))
+#else
+#define JSON_SCAN_NUMSTR_CREATE(sidx, eidx) \
+    PyUnicode_FromUnicode(&((Py_UNICODE *)str)[(sidx)], (eidx) - (sidx))
+#endif
+#define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_unicode(ns)
+#define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_unicode(s, ns)
+#define JSON_SCAN_MAYBE_ENCODING_DECL  ((void)0)
+#include "_speedups_scan.h"
+
+/* -- Generate the corresponding _str variants on Python 2. -- */
+#if PY_MAJOR_VERSION < 3
+#define JSON_SCAN_SUFFIX _str
+#define JSON_SCAN_DATA_INIT(p) \
+    char *str = PyString_AS_STRING(p); \
+    Py_ssize_t end_idx = PyString_GET_SIZE(p) - 1
+#define JSON_SCAN_READ(i) ((unsigned char)str[(i)])
+#define JSON_SCAN_SCANSTRING_CALL(pos, nextp) \
+    scanstring_str(state, pystr, (pos), encoding, s->strict, (nextp))
+#define JSON_SCAN_NUMSTR_CREATE(sidx, eidx) \
+    PyString_FromStringAndSize(&str[(sidx)], (eidx) - (sidx))
+#define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_str(ns)
+#define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_str(s, ns)
+#define JSON_SCAN_MAYBE_ENCODING_DECL  char *encoding = PyString_AS_STRING(s->encoding)
+#include "_speedups_scan.h"
 #endif /* PY_MAJOR_VERSION < 3 */
 
-
-static PyObject *
-scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
-{
-    /* Read one JSON term (of any kind) from PyUnicode pystr.
-    idx is the index of the first character of the term
-    *next_idx_ptr is a return-by-reference index to the first character after
-        the number.
-
-    Returns a new PyObject representation of the term.
-    */
-    _speedups_state *state = get_speedups_state(s->module_ref);
-    PY2_UNUSED int kind = PyUnicode_KIND(pystr);
-    void *str = PyUnicode_DATA(pystr);
-    Py_ssize_t length = PyUnicode_GET_LENGTH(pystr);
-    PyObject *rval = NULL;
-    int fallthrough = 0;
-    if (idx < 0 || idx >= length) {
-        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
-        return NULL;
-    }
-    switch (PyUnicode_READ(kind, str, idx)) {
-        case '"':
-            /* string */
-            rval = scanstring_unicode(state, pystr, idx + 1, s->strict,
-                                      next_idx_ptr);
-            break;
-        case '{':
-            /* object */
-            if (Py_EnterRecursiveCall(" while decoding a JSON object "
-                                      "from a unicode string"))
-                return NULL;
-            rval = _parse_object_unicode(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
-            break;
-        case '[':
-            /* array */
-            if (Py_EnterRecursiveCall(" while decoding a JSON array "
-                                      "from a unicode string"))
-                return NULL;
-            rval = _parse_array_unicode(s, pystr, idx + 1, next_idx_ptr);
-            Py_LeaveRecursiveCall();
-            break;
-        case 'n':
-            /* null */
-            if ((idx + 3 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'u' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'l' &&
-                PyUnicode_READ(kind, str, idx + 3) == 'l') {
-                Py_INCREF(Py_None);
-                *next_idx_ptr = idx + 4;
-                rval = Py_None;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 't':
-            /* true */
-            if ((idx + 3 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'r' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'u' &&
-                PyUnicode_READ(kind, str, idx + 3) == 'e') {
-                Py_INCREF(Py_True);
-                *next_idx_ptr = idx + 4;
-                rval = Py_True;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'f':
-            /* false */
-            if ((idx + 4 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'a' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'l' &&
-                PyUnicode_READ(kind, str, idx + 3) == 's' &&
-                PyUnicode_READ(kind, str, idx + 4) == 'e') {
-                Py_INCREF(Py_False);
-                *next_idx_ptr = idx + 5;
-                rval = Py_False;
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'N':
-            /* NaN */
-            if ((idx + 2 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'a' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'N') {
-                rval = _parse_constant(s, pystr, state->JSON_NaN, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        case 'I':
-            /* Infinity */
-            if ((idx + 7 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'n' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'f' &&
-                PyUnicode_READ(kind, str, idx + 3) == 'i' &&
-                PyUnicode_READ(kind, str, idx + 4) == 'n' &&
-                PyUnicode_READ(kind, str, idx + 5) == 'i' &&
-                PyUnicode_READ(kind, str, idx + 6) == 't' &&
-                PyUnicode_READ(kind, str, idx + 7) == 'y') {
-                rval = _parse_constant(s, pystr, state->JSON_Infinity, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        case '-':
-            /* -Infinity */
-            if ((idx + 8 < length) &&
-                PyUnicode_READ(kind, str, idx + 1) == 'I' &&
-                PyUnicode_READ(kind, str, idx + 2) == 'n' &&
-                PyUnicode_READ(kind, str, idx + 3) == 'f' &&
-                PyUnicode_READ(kind, str, idx + 4) == 'i' &&
-                PyUnicode_READ(kind, str, idx + 5) == 'n' &&
-                PyUnicode_READ(kind, str, idx + 6) == 'i' &&
-                PyUnicode_READ(kind, str, idx + 7) == 't' &&
-                PyUnicode_READ(kind, str, idx + 8) == 'y') {
-                rval = _parse_constant(s, pystr, state->JSON_NegInfinity, idx, next_idx_ptr);
-            }
-            else
-                fallthrough = 1;
-            break;
-        default:
-            fallthrough = 1;
-    }
-    /* Didn't find a string, object, array, or named constant. Look for a number. */
-    if (fallthrough)
-        rval = _match_number_unicode(s, pystr, idx, next_idx_ptr);
-    return rval;
-}
 
 static PyObject *
 scanner_call(PyObject *self, PyObject *args, PyObject *kwds)

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1024,18 +1024,18 @@ scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
             }
             /* Decode 4 hex digits */
             for (; next < end; next++) {
-                JSON_UNICHR digit = (JSON_UNICHR)buf[next];
+                JSON_UNICHR hex_digit = (JSON_UNICHR)buf[next];
                 c <<= 4;
-                switch (digit) {
+                switch (hex_digit) {
                     case '0': case '1': case '2': case '3': case '4':
                     case '5': case '6': case '7': case '8': case '9':
-                        c |= (digit - '0'); break;
+                        c |= (hex_digit - '0'); break;
                     case 'a': case 'b': case 'c': case 'd': case 'e':
                     case 'f':
-                        c |= (digit - 'a' + 10); break;
+                        c |= (hex_digit - 'a' + 10); break;
                     case 'A': case 'B': case 'C': case 'D': case 'E':
                     case 'F':
-                        c |= (digit - 'A' + 10); break;
+                        c |= (hex_digit - 'A' + 10); break;
                     default:
                         raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                         goto bail;
@@ -1050,17 +1050,17 @@ scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
                     /* Decode 4 hex digits */
                     for (next += 2; next < end; next++) {
                         c2 <<= 4;
-                        JSON_UNICHR digit = buf[next];
-                        switch (digit) {
+                        JSON_UNICHR hex_digit = buf[next];
+                        switch (hex_digit) {
                         case '0': case '1': case '2': case '3': case '4':
                         case '5': case '6': case '7': case '8': case '9':
-                            c2 |= (digit - '0'); break;
+                            c2 |= (hex_digit - '0'); break;
                         case 'a': case 'b': case 'c': case 'd': case 'e':
                         case 'f':
-                            c2 |= (digit - 'a' + 10); break;
+                            c2 |= (hex_digit - 'a' + 10); break;
                         case 'A': case 'B': case 'C': case 'D': case 'E':
                         case 'F':
-                            c2 |= (digit - 'A' + 10); break;
+                            c2 |= (hex_digit - 'A' + 10); break;
                         default:
                             raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                             goto bail;
@@ -1221,18 +1221,18 @@ scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
             }
             /* Decode 4 hex digits */
             for (; next < end; next++) {
-                JSON_UNICHR digit = PyUnicode_READ(kind, buf, next);
+                JSON_UNICHR hex_digit = PyUnicode_READ(kind, buf, next);
                 c <<= 4;
-                switch (digit) {
+                switch (hex_digit) {
                     case '0': case '1': case '2': case '3': case '4':
                     case '5': case '6': case '7': case '8': case '9':
-                        c |= (digit - '0'); break;
+                        c |= (hex_digit - '0'); break;
                     case 'a': case 'b': case 'c': case 'd': case 'e':
                     case 'f':
-                        c |= (digit - 'a' + 10); break;
+                        c |= (hex_digit - 'a' + 10); break;
                     case 'A': case 'B': case 'C': case 'D': case 'E':
                     case 'F':
-                        c |= (digit - 'A' + 10); break;
+                        c |= (hex_digit - 'A' + 10); break;
                     default:
                         raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                         goto bail;
@@ -1248,18 +1248,18 @@ scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
                     end += 6;
                     /* Decode 4 hex digits */
                     for (next += 2; next < end; next++) {
-                        JSON_UNICHR digit = PyUnicode_READ(kind, buf, next);
+                        JSON_UNICHR hex_digit = PyUnicode_READ(kind, buf, next);
                         c2 <<= 4;
-                        switch (digit) {
+                        switch (hex_digit) {
                         case '0': case '1': case '2': case '3': case '4':
                         case '5': case '6': case '7': case '8': case '9':
-                            c2 |= (digit - '0'); break;
+                            c2 |= (hex_digit - '0'); break;
                         case 'a': case 'b': case 'c': case 'd': case 'e':
                         case 'f':
-                            c2 |= (digit - 'a' + 10); break;
+                            c2 |= (hex_digit - 'a' + 10); break;
                         case 'A': case 'B': case 'C': case 'D': case 'E':
                         case 'F':
-                            c2 |= (digit - 'A' + 10); break;
+                            c2 |= (hex_digit - 'A' + 10); break;
                         default:
                             raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                             goto bail;
@@ -3055,7 +3055,6 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
             }
             else {
             PyObject *ident = NULL;
-            PyObject *newobj;
             if (s->iterable_as_array) {
                 newobj = PyObject_GetIter(obj);
                 if (newobj == NULL) {

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -13,7 +13,6 @@
 #define PyString_GET_SIZE PyUnicode_GET_LENGTH
 #define JSON_StringCheck PyUnicode_Check
 #define PY2_UNUSED
-#define PY3_UNUSED UNUSED
 #if PY_VERSION_HEX >= 0x030C0000
 /* PyUnicode_READY was deprecated in 3.10 and is a no-op since 3.12
  * (PEP 623). Skip calling it on modern Python to avoid the deprecation
@@ -23,7 +22,6 @@
 #endif
 #else /* PY_MAJOR_VERSION >= 3 */
 #define PY2_UNUSED UNUSED
-#define PY3_UNUSED
 #define JSON_StringCheck(obj) (PyString_Check(obj) || PyUnicode_Check(obj))
 #define PyBytes_Check PyString_Check
 #define PyUnicode_READY(obj) 0
@@ -458,6 +456,10 @@ JSON_Accu_FinishAsList(_speedups_state *state, JSON_Accu *acc)
 static void
 JSON_Accu_Destroy(JSON_Accu *acc)
 {
+    /* Safe to call unconditionally, including after JSON_Accu_FinishAsList
+     * (which clears small_strings and transfers ownership of
+     * large_strings to its return value). Py_CLEAR handles the NULL
+     * case, so repeat calls are no-ops. */
     Py_CLEAR(acc->small_strings);
     Py_CLEAR(acc->large_strings);
 }
@@ -471,31 +473,33 @@ IS_DIGIT(JSON_UNICHR c)
 static PyObject *
 maybe_quote_bigint(PyEncoderObject* s, PyObject *encoded, PyObject *obj)
 {
-    if (s->max_long_size != Py_None && s->min_long_size != Py_None) {
-        int ge, le;
-        ge = PyObject_RichCompareBool(obj, s->max_long_size, Py_GE);
-        if (ge < 0) {
-            Py_DECREF(encoded);
-            return NULL;
-        }
-        le = PyObject_RichCompareBool(obj, s->min_long_size, Py_LE);
-        if (le < 0) {
-            Py_DECREF(encoded);
-            return NULL;
-        }
-        if (ge || le) {
-#if PY_MAJOR_VERSION >= 3
-            PyObject* quoted = PyUnicode_FromFormat("\"%U\"", encoded);
-#else
-            PyObject* quoted = PyString_FromFormat("\"%s\"",
-                                                   PyString_AsString(encoded));
-#endif
-            Py_DECREF(encoded);
-            encoded = quoted;
-        }
-    }
+    int ge, le;
+    PyObject *quoted;
 
-    return encoded;
+    /* int_as_string_bitcount is not set: fast path, return as-is. */
+    if (s->max_long_size == Py_None || s->min_long_size == Py_None)
+        return encoded;
+
+    ge = PyObject_RichCompareBool(obj, s->max_long_size, Py_GE);
+    if (ge < 0) {
+        Py_DECREF(encoded);
+        return NULL;
+    }
+    le = PyObject_RichCompareBool(obj, s->min_long_size, Py_LE);
+    if (le < 0) {
+        Py_DECREF(encoded);
+        return NULL;
+    }
+    if (!(ge || le))
+        return encoded;
+
+#if PY_MAJOR_VERSION >= 3
+    quoted = PyUnicode_FromFormat("\"%U\"", encoded);
+#else
+    quoted = PyString_FromFormat("\"%s\"", PyString_AsString(encoded));
+#endif
+    Py_DECREF(encoded);
+    return quoted;
 }
 
 static int
@@ -1549,7 +1553,9 @@ _match_number_int_fast_str(PyScannerObject *s, PyObject *numstr)
 #endif
 #define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_unicode(ns)
 #define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_unicode(s, ns)
+#define JSON_SPEEDUPS_SCAN_INCLUDING 1
 #include "_speedups_scan.h"
+#undef JSON_SPEEDUPS_SCAN_INCLUDING
 
 /* -- Generate the corresponding _str variants on Python 2. -- */
 #if PY_MAJOR_VERSION < 3
@@ -1565,7 +1571,9 @@ _match_number_int_fast_str(PyScannerObject *s, PyObject *numstr)
     PyString_FromStringAndSize(&str[(sidx)], (eidx) - (sidx))
 #define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_str(ns)
 #define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_str(s, ns)
+#define JSON_SPEEDUPS_SCAN_INCLUDING 1
 #include "_speedups_scan.h"
+#undef JSON_SPEEDUPS_SCAN_INCLUDING
 #endif /* PY_MAJOR_VERSION < 3 */
 
 
@@ -1673,6 +1681,16 @@ scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             goto bail;
     }
 
+    /* Load required attributes from the Python-side JSONDecoder context.
+     * Each getattr failure is a hard error; goto bail lets scanner_dealloc
+     * release whatever we managed to set on s. */
+#define LOAD_ATTR(field, name)                              \
+    do {                                                    \
+        s->field = PyObject_GetAttrString(ctx, name);       \
+        if (s->field == NULL)                               \
+            goto bail;                                      \
+    } while (0)
+
     encoding = PyObject_GetAttrString(ctx, "encoding");
     if (encoding == NULL)
         goto bail;
@@ -1681,28 +1699,17 @@ scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (s->encoding == NULL)
         goto bail;
 
-    /* All of these will fail "gracefully" so we don't need to verify them */
-    s->strict_bool = PyObject_GetAttrString(ctx, "strict");
-    if (s->strict_bool == NULL)
-        goto bail;
+    LOAD_ATTR(strict_bool, "strict");
     s->strict = PyObject_IsTrue(s->strict_bool);
     if (s->strict < 0)
         goto bail;
-    s->object_hook = PyObject_GetAttrString(ctx, "object_hook");
-    if (s->object_hook == NULL)
-        goto bail;
-    s->pairs_hook = PyObject_GetAttrString(ctx, "object_pairs_hook");
-    if (s->pairs_hook == NULL)
-        goto bail;
-    s->parse_float = PyObject_GetAttrString(ctx, "parse_float");
-    if (s->parse_float == NULL)
-        goto bail;
-    s->parse_int = PyObject_GetAttrString(ctx, "parse_int");
-    if (s->parse_int == NULL)
-        goto bail;
-    s->parse_constant = PyObject_GetAttrString(ctx, "parse_constant");
-    if (s->parse_constant == NULL)
-        goto bail;
+    LOAD_ATTR(object_hook, "object_hook");
+    LOAD_ATTR(pairs_hook, "object_pairs_hook");
+    LOAD_ATTR(parse_float, "parse_float");
+    LOAD_ATTR(parse_int, "parse_int");
+    LOAD_ATTR(parse_constant, "parse_constant");
+
+#undef LOAD_ATTR
 
     return (PyObject *)s;
 
@@ -1733,8 +1740,7 @@ static PyType_Spec PyScannerType_spec = {
     .slots = PyScannerType_slots,
 };
 #else
-static
-PyTypeObject PyScannerType = {
+static PyTypeObject PyScannerType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "simplejson._speedups.Scanner",       /* tp_name */
     sizeof(PyScannerObject), /* tp_basicsize */
@@ -1811,7 +1817,35 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *ignore_nan, *Decimal;
     int is_true;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOOOOOOOOOOOOOOOOOO:make_encoder", kwlist,
+    /* Build the format string from per-argument pieces so that each "O"
+     * has a comment and adding/removing an argument only touches one
+     * line instead of counting letters in a 20-char string literal. The
+     * order here must match kwlist[] above and the &var argument list
+     * to PyArg_ParseTupleAndKeywords below. */
+    static const char *const fmt =
+        "O"  /* markers */
+        "O"  /* default */
+        "O"  /* encoder */
+        "O"  /* indent */
+        "O"  /* key_separator */
+        "O"  /* item_separator */
+        "O"  /* sort_keys */
+        "O"  /* skipkeys */
+        "O"  /* allow_nan */
+        "O"  /* key_memo */
+        "O"  /* use_decimal */
+        "O"  /* namedtuple_as_object */
+        "O"  /* tuple_as_array */
+        "O"  /* int_as_string_bitcount */
+        "O"  /* item_sort_key */
+        "O"  /* encoding */
+        "O"  /* for_json */
+        "O"  /* ignore_nan */
+        "O"  /* Decimal */
+        "O"  /* iterable_as_array */
+        ":make_encoder";
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, fmt, kwlist,
         &markers, &defaultfn, &encoder, &indent, &key_separator, &item_separator,
         &sort_keys, &skipkeys, &allow_nan, &key_memo, &use_decimal,
         &namedtuple_as_object, &tuple_as_array,
@@ -2098,6 +2132,46 @@ _steal_accumulate(_speedups_state *state, JSON_Accu *accu, PyObject *stolen)
     return rval;
 }
 
+/* Helper for the for_json / _asdict paths in encoder_listencode_obj.
+ * Steals the reference to `newobj` (returned by _call_json_method),
+ * handles recursion-depth tracking, and dispatches to the right
+ * sub-encoder:
+ *   - if as_dict is 0, encodes newobj as a generic JSON value via
+ *     encoder_listencode_obj (for_json contract: return any JSON-
+ *     compatible value);
+ *   - if as_dict is 1, encodes newobj as a dict via
+ *     encoder_listencode_dict after a TypeError-on-mismatch check
+ *     (_asdict contract: must return a dict).
+ * Cleans up on every exit path. */
+static int
+encoder_steal_encode(PyEncoderObject *s, JSON_Accu *rval,
+                     PyObject *newobj, Py_ssize_t indent_level,
+                     int as_dict)
+{
+    int rv;
+    if (newobj == NULL)
+        return -1;
+    if (Py_EnterRecursiveCall(" while encoding a JSON object")) {
+        Py_DECREF(newobj);
+        return -1;
+    }
+    if (as_dict) {
+        if (PyDict_Check(newobj)) {
+            rv = encoder_listencode_dict(s, rval, newobj, indent_level);
+        } else {
+            PyErr_Format(PyExc_TypeError,
+                         "_asdict() must return a dict, not %.80s",
+                         Py_TYPE(newobj)->tp_name);
+            rv = -1;
+        }
+    } else {
+        rv = encoder_listencode_obj(s, rval, newobj, indent_level);
+    }
+    Py_DECREF(newobj);
+    Py_LeaveRecursiveCall();
+    return rv;
+}
+
 static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level)
 {
@@ -2147,37 +2221,10 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 rv = _steal_accumulate(state, rval, encoded);
         }
         else if (s->for_json && _call_json_method(obj, state->JSON_attr_for_json, &newobj)) {
-            if (newobj == NULL) {
-                return -1;
-            }
-            if (Py_EnterRecursiveCall(" while encoding a JSON object")) {
-                Py_DECREF(newobj);
-                return rv;
-            }
-            rv = encoder_listencode_obj(s, rval, newobj, indent_level);
-            Py_DECREF(newobj);
-            Py_LeaveRecursiveCall();
+            rv = encoder_steal_encode(s, rval, newobj, indent_level, /*as_dict=*/0);
         }
         else if (s->namedtuple_as_object && _call_json_method(obj, state->JSON_attr_asdict, &newobj)) {
-            if (newobj == NULL) {
-                return -1;
-            }
-            if (Py_EnterRecursiveCall(" while encoding a JSON object")) {
-                Py_DECREF(newobj);
-                return rv;
-            }
-            if (PyDict_Check(newobj)) {
-                rv = encoder_listencode_dict(s, rval, newobj, indent_level);
-            } else {
-                PyErr_Format(
-                    PyExc_TypeError,
-                    "_asdict() must return a dict, not %.80s",
-                    Py_TYPE(newobj)->tp_name
-                );
-                rv = -1;
-            }
-            Py_DECREF(newobj);
-            Py_LeaveRecursiveCall();
+            rv = encoder_steal_encode(s, rval, newobj, indent_level, /*as_dict=*/1);
         }
         else if (PyList_Check(obj) || (s->tuple_as_array && PyTuple_Check(obj))) {
             if (Py_EnterRecursiveCall(" while encoding a JSON object"))
@@ -2580,8 +2627,7 @@ static PyType_Spec PyEncoderType_spec = {
     .slots = PyEncoderType_slots,
 };
 #else
-static
-PyTypeObject PyEncoderType = {
+static PyTypeObject PyEncoderType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "simplejson._speedups.Encoder",       /* tp_name */
     sizeof(PyEncoderObject), /* tp_basicsize */

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -90,10 +90,8 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
    accesses it via get_speedups_state(module_ref) so that call sites
    look identical on all versions. */
 typedef struct {
-#if PY_VERSION_HEX >= 0x030D0000
     PyObject *PyScannerType;
     PyObject *PyEncoderType;
-#endif
     PyObject *JSON_Infinity;
     PyObject *JSON_NegInfinity;
     PyObject *JSON_NaN;
@@ -3746,10 +3744,18 @@ static PyObject *
 moduleinit(void)
 {
     PyObject *m;
+    _speedups_state *state = &_speedups_static_state;
+
     if (PyType_Ready(&PyScannerType) < 0)
         return NULL;
     if (PyType_Ready(&PyEncoderType) < 0)
         return NULL;
+
+    /* Static types are eternal, so these are borrowed pointers kept
+       in the state struct for layout uniformity with the 3.13+ path.
+       There's no refcount to manage and no GC tracking here. */
+    state->PyScannerType = (PyObject *)&PyScannerType;
+    state->PyEncoderType = (PyObject *)&PyEncoderType;
 
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
@@ -3762,20 +3768,20 @@ moduleinit(void)
     /* Borrowed reference - sys.modules keeps the module alive. */
     _speedups_module = m;
 
-    Py_INCREF((PyObject*)&PyScannerType);
-    if (PyModule_AddObject(m, "make_scanner", (PyObject*)&PyScannerType) < 0) {
-        Py_DECREF((PyObject*)&PyScannerType);
+    Py_INCREF(state->PyScannerType);
+    if (PyModule_AddObject(m, "make_scanner", state->PyScannerType) < 0) {
+        Py_DECREF(state->PyScannerType);
         Py_DECREF(m);
         return NULL;
     }
-    Py_INCREF((PyObject*)&PyEncoderType);
-    if (PyModule_AddObject(m, "make_encoder", (PyObject*)&PyEncoderType) < 0) {
-        Py_DECREF((PyObject*)&PyEncoderType);
+    Py_INCREF(state->PyEncoderType);
+    if (PyModule_AddObject(m, "make_encoder", state->PyEncoderType) < 0) {
+        Py_DECREF(state->PyEncoderType);
         Py_DECREF(m);
         return NULL;
     }
 
-    if (init_speedups_state(&_speedups_static_state, m) < 0) {
+    if (init_speedups_state(state, m) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -156,9 +156,9 @@ typedef struct {
 static int
 JSON_Accu_Init(JSON_Accu *acc);
 static int
-JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode, _speedups_state *state);
+JSON_Accu_Accumulate(_speedups_state *state, JSON_Accu *acc, PyObject *unicode);
 static PyObject *
-JSON_Accu_FinishAsList(JSON_Accu *acc, _speedups_state *state);
+JSON_Accu_FinishAsList(_speedups_state *state, JSON_Accu *acc);
 static void
 JSON_Accu_Destroy(JSON_Accu *acc);
 
@@ -250,7 +250,7 @@ static PyMemberDef encoder_members[] = {
 };
 
 static PyObject *
-join_list_unicode(PyObject *lst, _speedups_state *state);
+join_list_unicode(_speedups_state *state, PyObject *lst);
 static PyObject *
 JSON_ParseEncoding(PyObject *encoding);
 static PyObject *
@@ -267,18 +267,18 @@ static PyObject *
 py_encode_basestring_ascii(PyObject* self UNUSED, PyObject *pystr);
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-join_list_string(PyObject *lst, _speedups_state *state);
+join_list_string(_speedups_state *state, PyObject *lst);
 static PyObject *
 scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
-scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
-               Py_ssize_t *next_end_ptr, _speedups_state *state);
+scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
+               char *encoding, int strict, Py_ssize_t *next_end_ptr);
 static PyObject *
 _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 #endif
 static PyObject *
-scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
-                   _speedups_state *state);
+scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
+                   int strict, Py_ssize_t *next_end_ptr);
 static PyObject *
 scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
@@ -296,7 +296,7 @@ encoder_dealloc(PyObject *self);
 static int
 encoder_clear(PyObject *self);
 static int
-is_raw_json(PyObject *obj, _speedups_state *state);
+is_raw_json(_speedups_state *state, PyObject *obj);
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key);
 static int
@@ -306,9 +306,9 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
 static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level);
 static PyObject *
-_encoded_const(PyObject *obj, _speedups_state *state);
+_encoded_const(_speedups_state *state, PyObject *obj);
 static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state);
+raise_errmsg(_speedups_state *state, char *msg, PyObject *s, Py_ssize_t end);
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -334,7 +334,7 @@ import_dependency(char *module_name, char *attr_name);
 #define MIN_EXPANSION 6
 
 static int
-is_raw_json(PyObject *obj, _speedups_state *state)
+is_raw_json(_speedups_state *state, PyObject *obj)
 {
     int r = PyObject_IsInstance(obj, state->RawJSONType);
     if (r < 0)
@@ -354,7 +354,7 @@ JSON_Accu_Init(JSON_Accu *acc)
 }
 
 static int
-flush_accumulator(JSON_Accu *acc, _speedups_state *state)
+flush_accumulator(_speedups_state *state, JSON_Accu *acc)
 {
     Py_ssize_t nsmall = PyList_GET_SIZE(acc->small_strings);
     if (nsmall) {
@@ -366,9 +366,9 @@ flush_accumulator(JSON_Accu *acc, _speedups_state *state)
                 return -1;
         }
 #if PY_MAJOR_VERSION >= 3
-        joined = join_list_unicode(acc->small_strings, state);
+        joined = join_list_unicode(state, acc->small_strings);
 #else
-        joined = join_list_string(acc->small_strings, state);
+        joined = join_list_string(state, acc->small_strings);
 #endif
         if (joined == NULL)
             return -1;
@@ -384,7 +384,7 @@ flush_accumulator(JSON_Accu *acc, _speedups_state *state)
 }
 
 static int
-JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode, _speedups_state *state)
+JSON_Accu_Accumulate(_speedups_state *state, JSON_Accu *acc, PyObject *unicode)
 {
     Py_ssize_t nsmall;
 #if PY_MAJOR_VERSION >= 3
@@ -405,16 +405,16 @@ JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode, _speedups_state *state)
      */
     if (nsmall < 100000)
         return 0;
-    return flush_accumulator(acc, state);
+    return flush_accumulator(state, acc);
 }
 
 static PyObject *
-JSON_Accu_FinishAsList(JSON_Accu *acc, _speedups_state *state)
+JSON_Accu_FinishAsList(_speedups_state *state, JSON_Accu *acc)
 {
     int ret;
     PyObject *res;
 
-    ret = flush_accumulator(acc, state);
+    ret = flush_accumulator(state, acc);
     Py_CLEAR(acc->small_strings);
     if (ret) {
         Py_CLEAR(acc->large_strings);
@@ -716,7 +716,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
     else if (key == Py_True || key == Py_False || key == Py_None) {
         /* This must come before the PyInt_Check because
            True and False are also 1 and 0.*/
-        return _encoded_const(key, state);
+        return _encoded_const(state, key);
     }
     else if (PyInt_Check(key) || PyLong_Check(key)) {
         if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
@@ -840,7 +840,7 @@ bail:
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
 static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state)
+raise_errmsg(_speedups_state *state, char *msg, PyObject *s, Py_ssize_t end)
 {
     PyObject *JSONDecodeError = state->JSONDecodeError;
     PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
@@ -851,7 +851,7 @@ raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state)
 }
 
 static PyObject *
-join_list_unicode(PyObject *lst, _speedups_state *state)
+join_list_unicode(_speedups_state *state, PyObject *lst)
 {
     /* return u''.join(lst) */
     return PyUnicode_Join(state->JSON_EmptyUnicode, lst);
@@ -859,7 +859,7 @@ join_list_unicode(PyObject *lst, _speedups_state *state)
 
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-join_list_string(PyObject *lst, _speedups_state *state)
+join_list_string(_speedups_state *state, PyObject *lst)
 {
     /* return ''.join(lst) */
     static PyObject *joinfn = NULL;
@@ -917,8 +917,8 @@ _build_rval_index_tuple(PyObject *rval, Py_ssize_t idx)
 
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
-               Py_ssize_t *next_end_ptr, _speedups_state *state)
+scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
+               char *encoding, int strict, Py_ssize_t *next_end_ptr)
 {
     /* Read the JSON string from PyString pystr.
     end is the index of the first character after the quote.
@@ -940,7 +940,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
     PyObject *strchunk = NULL;
 
     if (len == end) {
-        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+        raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -956,7 +956,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
                 break;
             }
             else if (strict && c <= 0x1f) {
-                raise_errmsg(ERR_STRING_CONTROL, pystr, next, state);
+                raise_errmsg(state, ERR_STRING_CONTROL, pystr, next);
                 goto bail;
             }
             else if (c > 0x7f) {
@@ -964,7 +964,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
             }
         }
         if (!(c == '"' || c == '\\')) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -991,7 +991,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
             break;
         }
         if (next == len) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
             goto bail;
         }
         c = buf[next];
@@ -1010,7 +1010,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2, state);
+                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 2);
                 goto bail;
             }
         }
@@ -1019,7 +1019,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
             next++;
             end = next + 4;
             if (end >= len) {
-                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1, state);
+                raise_errmsg(state, ERR_STRING_ESC4, pystr, next - 1);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1037,7 +1037,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
+                        raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                         goto bail;
                 }
             }
@@ -1062,7 +1062,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
+                            raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                             goto bail;
                         }
                     }
@@ -1107,7 +1107,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
     }
     else {
         APPEND_OLD_CHUNK
-        rval = join_list_string(chunks, state);
+        rval = join_list_string(state, chunks);
         if (rval == NULL) {
             goto bail;
         }
@@ -1125,8 +1125,8 @@ bail:
 #endif /* PY_MAJOR_VERSION < 3 */
 
 static PyObject *
-scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
-                   _speedups_state *state)
+scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
+                   int strict, Py_ssize_t *next_end_ptr)
 {
     /* Read the JSON string from PyUnicode pystr.
     end is the index of the first character after the quote.
@@ -1146,7 +1146,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     PyObject *chunk = NULL;
 
     if (len == end) {
-        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+        raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -1162,12 +1162,12 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 break;
             }
             else if (strict && c <= 0x1f) {
-                raise_errmsg(ERR_STRING_CONTROL, pystr, next, state);
+                raise_errmsg(state, ERR_STRING_CONTROL, pystr, next);
                 goto bail;
             }
         }
         if (!(c == '"' || c == '\\')) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -1188,7 +1188,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             break;
         }
         if (next == len) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(state, ERR_STRING_UNTERMINATED, pystr, begin);
             goto bail;
         }
         c = PyUnicode_READ(kind, buf, next);
@@ -1207,7 +1207,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2, state);
+                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 2);
                 goto bail;
             }
         }
@@ -1216,7 +1216,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             next++;
             end = next + 4;
             if (end >= len) {
-                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1, state);
+                raise_errmsg(state, ERR_STRING_ESC4, pystr, next - 1);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1234,7 +1234,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
+                        raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                         goto bail;
                 }
             }
@@ -1261,7 +1261,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
+                            raise_errmsg(state, ERR_STRING_ESC4, pystr, end - 5);
                             goto bail;
                         }
                     }
@@ -1294,7 +1294,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     }
     else {
         APPEND_OLD_CHUNK
-        rval = join_list_unicode(chunks, state);
+        rval = join_list_unicode(state, chunks);
         if (rval == NULL) {
             goto bail;
         }
@@ -1340,15 +1340,15 @@ py_scanstring(PyObject* self UNUSED, PyObject *args)
     if (PyUnicode_Check(pystr)) {
         if (PyUnicode_READY(pystr))
             return NULL;
-        rval = scanstring_unicode(pystr, end, strict, &next_end,
-                                  get_speedups_state(self));
+        rval = scanstring_unicode(get_speedups_state(self), pystr, end,
+                                  strict, &next_end);
     }
 #if PY_MAJOR_VERSION < 3
     /* Using a bytes input is unsupported for scanning in Python 3.
        It is coerced to str in the decoder before it gets here. */
     else if (PyString_Check(pystr)) {
-        rval = scanstring_str(pystr, end, encoding, strict, &next_end,
-                              get_speedups_state(self));
+        rval = scanstring_str(get_speedups_state(self), pystr, end,
+                              encoding, strict, &next_end);
     }
 #endif
     else {
@@ -1490,10 +1490,10 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 
             /* read key */
             if (str[idx] != '"') {
-                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
                 goto bail;
             }
-            key = scanstring_str(pystr, idx + 1, encoding, s->strict, &next_idx, state);
+            key = scanstring_str(state, pystr, idx + 1, encoding, s->strict, &next_idx);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1514,7 +1514,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             /* skip whitespace between key and : delimiter, read :, skip whitespace */
             while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
             if (idx > end_idx || str[idx] != ':') {
-                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1555,7 +1555,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 break;
             }
             else if (str[idx] != ',') {
-                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1565,16 +1565,16 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
             goto bail;
         }
     }
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || str[idx] != '}') {
         if (did_parse) {
-            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
         } else {
-            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
         }
         goto bail;
     }
@@ -1655,10 +1655,10 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
             /* read key */
             if (PyUnicode_READ(kind, str, idx) != '"') {
-                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
                 goto bail;
             }
-            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx, state);
+            key = scanstring_unicode(state, pystr, idx + 1, s->strict, &next_idx);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1680,7 +1680,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                whitespace */
             while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
             if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
-                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1722,7 +1722,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1732,7 +1732,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
             goto bail;
         }
     }
@@ -1740,9 +1740,9 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
         if (did_parse) {
-            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
         } else {
-            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, state);
+            raise_errmsg(state, ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
         }
         goto bail;
     }
@@ -1825,7 +1825,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
                 break;
             }
             else if (str[idx] != ',') {
-                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1835,7 +1835,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
             goto bail;
         }
     }
@@ -1843,9 +1843,9 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || str[idx] != ']') {
         if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
+            raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
         } else {
-            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx, state);
+            raise_errmsg(state, ERR_ARRAY_VALUE_FIRST, pystr, idx);
         }
         goto bail;
     }
@@ -1907,7 +1907,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
+                raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
                 goto bail;
             }
             idx++;
@@ -1917,7 +1917,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
             goto bail;
         }
     }
@@ -1925,9 +1925,9 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
         if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
+            raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
         } else {
-            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx, state);
+            raise_errmsg(state, ERR_ARRAY_VALUE_FIRST, pystr, idx);
         }
         goto bail;
     }
@@ -1953,8 +1953,8 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
     */
     PyObject *rval;
     if (s->parse_constant == Py_None) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx,
-                          get_speedups_state(s->module_ref));
+        raise_errmsg(get_speedups_state(s->module_ref),
+                     ERR_EXPECTING_VALUE, pystr, idx);
         return NULL;
     }
 
@@ -1989,7 +1989,7 @@ _match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssiz
     /* read a sign if it's there, make sure it's not the end of the string */
     if (str[idx] == '-') {
         if (idx >= end_idx) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
             return NULL;
         }
         idx++;
@@ -2006,7 +2006,7 @@ _match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssiz
     }
     /* no integer digits, error */
     else {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
         return NULL;
     }
 
@@ -2099,7 +2099,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     /* read a sign if it's there, make sure it's not the end of the string */
     if (PyUnicode_READ(kind, str, idx) == '-') {
         if (idx >= end_idx) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
             return NULL;
         }
         idx++;
@@ -2119,7 +2119,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     }
     else {
         /* no integer digits, error */
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
         return NULL;
     }
 
@@ -2203,15 +2203,15 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
         return NULL;
     }
     switch (str[idx]) {
         case '"':
             /* string */
-            rval = scanstring_str(pystr, idx + 1,
+            rval = scanstring_str(state, pystr, idx + 1,
                                   PyString_AS_STRING(s->encoding),
-                                  s->strict, next_idx_ptr, state);
+                                  s->strict, next_idx_ptr);
             break;
         case '{':
             /* object */
@@ -2311,14 +2311,14 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
         return NULL;
     }
     switch (PyUnicode_READ(kind, str, idx)) {
         case '"':
             /* string */
-            rval = scanstring_unicode(pystr, idx + 1, s->strict,
-                                      next_idx_ptr, state);
+            rval = scanstring_unicode(state, pystr, idx + 1, s->strict,
+                                      next_idx_ptr);
             break;
         case '{':
             /* object */
@@ -2842,11 +2842,11 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
         JSON_Accu_Destroy(&rval);
         return NULL;
     }
-    return JSON_Accu_FinishAsList(&rval, state);
+    return JSON_Accu_FinishAsList(state, &rval);
 }
 
 static PyObject *
-_encoded_const(PyObject *obj, _speedups_state *state)
+_encoded_const(_speedups_state *state, PyObject *obj)
 {
     /* Return the JSON string representation of None, True, False */
     if (obj == Py_None) {
@@ -2879,7 +2879,7 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
             return NULL;
         }
         if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
-            return _encoded_const(Py_None, state);
+            return _encoded_const(state, Py_None);
         }
         /* JSON_ALLOW_NAN is set */
         else if (i > 0) {
@@ -2938,10 +2938,10 @@ encoder_encode_string(PyEncoderObject *s, PyObject *obj)
 }
 
 static int
-_steal_accumulate(JSON_Accu *accu, PyObject *stolen, _speedups_state *state)
+_steal_accumulate(_speedups_state *state, JSON_Accu *accu, PyObject *stolen)
 {
     /* Append stolen and then decrement its reference count */
-    int rval = JSON_Accu_Accumulate(accu, stolen, state);
+    int rval = JSON_Accu_Accumulate(state, accu, stolen);
     Py_DECREF(stolen);
     return rval;
 }
@@ -2955,16 +2955,16 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
     do {
         PyObject *newobj;
         if (obj == Py_None || obj == Py_True || obj == Py_False) {
-            PyObject *cstr = _encoded_const(obj, state);
+            PyObject *cstr = _encoded_const(state, obj);
             if (cstr != NULL)
-                rv = _steal_accumulate(rval, cstr, state);
+                rv = _steal_accumulate(state, rval, cstr);
         }
         else if ((PyBytes_Check(obj) && s->encoding != NULL) ||
                  PyUnicode_Check(obj))
         {
             PyObject *encoded = encoder_encode_string(s, obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded, state);
+                rv = _steal_accumulate(state, rval, encoded);
         }
         else if (PyInt_Check(obj) || PyLong_Check(obj)) {
             PyObject *encoded;
@@ -2986,13 +2986,13 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 encoded = maybe_quote_bigint(s, encoded, obj);
                 if (encoded == NULL)
                     break;
-                rv = _steal_accumulate(rval, encoded, state);
+                rv = _steal_accumulate(state, rval, encoded);
             }
         }
         else if (PyFloat_Check(obj)) {
             PyObject *encoded = encoder_encode_float(s, obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded, state);
+                rv = _steal_accumulate(state, rval, encoded);
         }
         else if (s->for_json && _call_json_method(obj, FOR_JSON_METHOD_NAME, &newobj)) {
             if (newobj == NULL) {
@@ -3042,16 +3042,16 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
         else if (s->use_decimal && PyObject_TypeCheck(obj, (PyTypeObject *)s->Decimal)) {
             PyObject *encoded = PyObject_Str(obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded, state);
+                rv = _steal_accumulate(state, rval, encoded);
         }
         else {
-            int raw = is_raw_json(obj, state);
+            int raw = is_raw_json(state, obj);
             if (raw < 0)
                 break;
             if (raw) {
                 PyObject *encoded = PyObject_GetAttrString(obj, "encoded_json");
                 if (encoded != NULL)
-                    rv = _steal_accumulate(rval, encoded, state);
+                    rv = _steal_accumulate(state, rval, encoded);
             }
             else {
             PyObject *ident = NULL;
@@ -3129,7 +3129,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
     Py_ssize_t idx;
 
     if (PyDict_Size(dct) == 0)
-        return JSON_Accu_Accumulate(rval, state->JSON_empty_dict, state);
+        return JSON_Accu_Accumulate(state, rval, state->JSON_empty_dict);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3147,7 +3147,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
         }
     }
 
-    if (JSON_Accu_Accumulate(rval, state->JSON_open_dict, state))
+    if (JSON_Accu_Accumulate(state, rval, state->JSON_open_dict))
         goto bail;
 
     if (s->indent != Py_None) {
@@ -3188,7 +3188,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             continue;
         }
         if (idx) {
-            if (JSON_Accu_Accumulate(rval, s->item_separator, state))
+            if (JSON_Accu_Accumulate(state, rval, s->item_separator))
                 goto bail;
         }
         /*
@@ -3210,11 +3210,11 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             if (PyDict_SetItem(s->key_memo, key, encoded))
                 goto bail;
         }
-        if (JSON_Accu_Accumulate(rval, encoded, state)) {
+        if (JSON_Accu_Accumulate(state, rval, encoded)) {
             goto bail;
         }
         Py_CLEAR(encoded);
-        if (JSON_Accu_Accumulate(rval, s->key_separator, state))
+        if (JSON_Accu_Accumulate(state, rval, s->key_separator))
             goto bail;
         if (encoder_listencode_obj(s, rval, value, indent_level))
             goto bail;
@@ -3236,7 +3236,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, state->JSON_close_dict, state))
+    if (JSON_Accu_Accumulate(state, rval, state->JSON_close_dict))
         goto bail;
     return 0;
 
@@ -3267,7 +3267,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (is_true == -1)
         return -1;
     else if (is_true == 0)
-        return JSON_Accu_Accumulate(rval, state->JSON_empty_array, state);
+        return JSON_Accu_Accumulate(state, rval, state->JSON_empty_array);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3289,7 +3289,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (iter == NULL)
         goto bail;
 
-    if (JSON_Accu_Accumulate(rval, state->JSON_open_array, state))
+    if (JSON_Accu_Accumulate(state, rval, state->JSON_open_array))
         goto bail;
     if (s->indent != Py_None) {
         /* TODO: DOES NOT RUN */
@@ -3302,7 +3302,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     }
     while ((obj = PyIter_Next(iter))) {
         if (i) {
-            if (JSON_Accu_Accumulate(rval, s->item_separator, state))
+            if (JSON_Accu_Accumulate(state, rval, s->item_separator))
                 goto bail;
         }
         if (encoder_listencode_obj(s, rval, obj, indent_level))
@@ -3325,7 +3325,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, state->JSON_close_array, state))
+    if (JSON_Accu_Accumulate(state, rval, state->JSON_close_array))
         goto bail;
     return 0;
 

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -151,15 +151,14 @@ get_speedups_state(PyObject *module)
 typedef struct {
     PyObject *large_strings;  /* A list of previously accumulated large strings */
     PyObject *small_strings;  /* Pending small strings */
-    _speedups_state *state;   /* borrowed */
 } JSON_Accu;
 
 static int
-JSON_Accu_Init(JSON_Accu *acc, _speedups_state *state);
+JSON_Accu_Init(JSON_Accu *acc);
 static int
-JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode);
+JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode, _speedups_state *state);
 static PyObject *
-JSON_Accu_FinishAsList(JSON_Accu *acc);
+JSON_Accu_FinishAsList(JSON_Accu *acc, _speedups_state *state);
 static void
 JSON_Accu_Destroy(JSON_Accu *acc);
 
@@ -268,11 +267,12 @@ static PyObject *
 py_encode_basestring_ascii(PyObject* self UNUSED, PyObject *pystr);
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-join_list_string(PyObject *lst);
+join_list_string(PyObject *lst, _speedups_state *state);
 static PyObject *
 scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
-scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_ssize_t *next_end_ptr);
+scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
+               Py_ssize_t *next_end_ptr, _speedups_state *state);
 static PyObject *
 _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 #endif
@@ -308,7 +308,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
 static PyObject *
 _encoded_const(PyObject *obj, _speedups_state *state);
 static void
-raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state);
+raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state);
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -328,13 +328,6 @@ init_speedups_state(_speedups_state *state, PyObject *module);
 static PyObject *
 import_dependency(char *module_name, char *attr_name);
 
-#if PY_MAJOR_VERSION < 3
-/* Python 2 scanner functions don't thread state through explicitly,
-   so the 3-arg form resolves state from the single static instance. */
-#define raise_errmsg(msg, s, end) \
-    raise_errmsg_impl(msg, s, end, &_speedups_static_state)
-#endif
-
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
 
@@ -350,19 +343,18 @@ is_raw_json(PyObject *obj, _speedups_state *state)
 }
 
 static int
-JSON_Accu_Init(JSON_Accu *acc, _speedups_state *state)
+JSON_Accu_Init(JSON_Accu *acc)
 {
     /* Lazily allocated */
     acc->large_strings = NULL;
     acc->small_strings = PyList_New(0);
     if (acc->small_strings == NULL)
         return -1;
-    acc->state = state;  /* borrowed */
     return 0;
 }
 
 static int
-flush_accumulator(JSON_Accu *acc)
+flush_accumulator(JSON_Accu *acc, _speedups_state *state)
 {
     Py_ssize_t nsmall = PyList_GET_SIZE(acc->small_strings);
     if (nsmall) {
@@ -374,9 +366,9 @@ flush_accumulator(JSON_Accu *acc)
                 return -1;
         }
 #if PY_MAJOR_VERSION >= 3
-        joined = join_list_unicode(acc->small_strings, acc->state);
+        joined = join_list_unicode(acc->small_strings, state);
 #else
-        joined = join_list_string(acc->small_strings);
+        joined = join_list_string(acc->small_strings, state);
 #endif
         if (joined == NULL)
             return -1;
@@ -392,7 +384,7 @@ flush_accumulator(JSON_Accu *acc)
 }
 
 static int
-JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode)
+JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode, _speedups_state *state)
 {
     Py_ssize_t nsmall;
 #if PY_MAJOR_VERSION >= 3
@@ -413,16 +405,16 @@ JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode)
      */
     if (nsmall < 100000)
         return 0;
-    return flush_accumulator(acc);
+    return flush_accumulator(acc, state);
 }
 
 static PyObject *
-JSON_Accu_FinishAsList(JSON_Accu *acc)
+JSON_Accu_FinishAsList(JSON_Accu *acc, _speedups_state *state)
 {
     int ret;
     PyObject *res;
 
-    ret = flush_accumulator(acc);
+    ret = flush_accumulator(acc, state);
     Py_CLEAR(acc->small_strings);
     if (ret) {
         Py_CLEAR(acc->large_strings);
@@ -696,7 +688,7 @@ ascii_escape_str(PyObject *pystr)
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 {
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     if (PyUnicode_Check(key)) {
         Py_INCREF(key);
         return key;
@@ -724,7 +716,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
     else if (key == Py_True || key == Py_False || key == Py_None) {
         /* This must come before the PyInt_Check because
            True and False are also 1 and 0.*/
-        return _encoded_const(key, _st);
+        return _encoded_const(key, state);
     }
     else if (PyInt_Check(key) || PyLong_Check(key)) {
         if (!(PyInt_CheckExact(key) || PyLong_CheckExact(key))) {
@@ -758,7 +750,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 static PyObject *
 encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
 {
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PyObject *items;
     PyObject *iter = NULL;
     PyObject *lst = NULL;
@@ -829,7 +821,7 @@ encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
     sortfun = PyObject_GetAttrString(lst, "sort");
     if (sortfun == NULL)
         goto bail;
-    sortres = PyObject_Call(sortfun, _st->JSON_sortargs, s->item_sort_kw);
+    sortres = PyObject_Call(sortfun, state->JSON_sortargs, s->item_sort_kw);
     if (!sortres)
         goto bail;
     Py_DECREF(sortres);
@@ -848,7 +840,7 @@ bail:
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
 static void
-raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state)
+raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, _speedups_state *state)
 {
     PyObject *JSONDecodeError = state->JSONDecodeError;
     PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
@@ -867,12 +859,12 @@ join_list_unicode(PyObject *lst, _speedups_state *state)
 
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-join_list_string(PyObject *lst)
+join_list_string(PyObject *lst, _speedups_state *state)
 {
     /* return ''.join(lst) */
     static PyObject *joinfn = NULL;
     if (joinfn == NULL) {
-        joinfn = PyObject_GetAttrString(_speedups_static_state.JSON_EmptyStr, "join");
+        joinfn = PyObject_GetAttrString(state->JSON_EmptyStr, "join");
         if (joinfn == NULL)
             return NULL;
     }
@@ -925,7 +917,8 @@ _build_rval_index_tuple(PyObject *rval, Py_ssize_t idx)
 
 #if PY_MAJOR_VERSION < 3
 static PyObject *
-scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_ssize_t *next_end_ptr)
+scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict,
+               Py_ssize_t *next_end_ptr, _speedups_state *state)
 {
     /* Read the JSON string from PyString pystr.
     end is the index of the first character after the quote.
@@ -947,7 +940,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
     PyObject *strchunk = NULL;
 
     if (len == end) {
-        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -963,7 +956,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
                 break;
             }
             else if (strict && c <= 0x1f) {
-                raise_errmsg(ERR_STRING_CONTROL, pystr, next);
+                raise_errmsg(ERR_STRING_CONTROL, pystr, next, state);
                 goto bail;
             }
             else if (c > 0x7f) {
@@ -971,7 +964,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
             }
         }
         if (!(c == '"' || c == '\\')) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -998,7 +991,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
             break;
         }
         if (next == len) {
-            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin);
+            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         c = buf[next];
@@ -1017,7 +1010,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2);
+                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2, state);
                 goto bail;
             }
         }
@@ -1026,7 +1019,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
             next++;
             end = next + 4;
             if (end >= len) {
-                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1);
+                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1, state);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1044,7 +1037,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5);
+                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
                         goto bail;
                 }
             }
@@ -1069,7 +1062,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5);
+                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
                             goto bail;
                         }
                     }
@@ -1108,13 +1101,13 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
         if (chunk != NULL)
             rval = chunk;
         else {
-            rval = _speedups_static_state.JSON_EmptyStr;
+            rval = state->JSON_EmptyStr;
             Py_INCREF(rval);
         }
     }
     else {
         APPEND_OLD_CHUNK
-        rval = join_list_string(chunks);
+        rval = join_list_string(chunks, state);
         if (rval == NULL) {
             goto bail;
         }
@@ -1153,7 +1146,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     PyObject *chunk = NULL;
 
     if (len == end) {
-        raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
+        raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
         goto bail;
     }
     else if (end < 0 || len < end) {
@@ -1169,12 +1162,12 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 break;
             }
             else if (strict && c <= 0x1f) {
-                raise_errmsg_impl(ERR_STRING_CONTROL, pystr, next, state);
+                raise_errmsg(ERR_STRING_CONTROL, pystr, next, state);
                 goto bail;
             }
         }
         if (!(c == '"' || c == '\\')) {
-            raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         /* Pick up this chunk if it's not zero length */
@@ -1195,7 +1188,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             break;
         }
         if (next == len) {
-            raise_errmsg_impl(ERR_STRING_UNTERMINATED, pystr, begin, state);
+            raise_errmsg(ERR_STRING_UNTERMINATED, pystr, begin, state);
             goto bail;
         }
         c = PyUnicode_READ(kind, buf, next);
@@ -1214,7 +1207,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg_impl(ERR_STRING_ESC1, pystr, end - 2, state);
+                raise_errmsg(ERR_STRING_ESC1, pystr, end - 2, state);
                 goto bail;
             }
         }
@@ -1223,7 +1216,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             next++;
             end = next + 4;
             if (end >= len) {
-                raise_errmsg_impl(ERR_STRING_ESC4, pystr, next - 1, state);
+                raise_errmsg(ERR_STRING_ESC4, pystr, next - 1, state);
                 goto bail;
             }
             /* Decode 4 hex digits */
@@ -1241,7 +1234,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                     case 'F':
                         c |= (digit - 'A' + 10); break;
                     default:
-                        raise_errmsg_impl(ERR_STRING_ESC4, pystr, end - 5, state);
+                        raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
                         goto bail;
                 }
             }
@@ -1268,7 +1261,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                         case 'F':
                             c2 |= (digit - 'A' + 10); break;
                         default:
-                            raise_errmsg_impl(ERR_STRING_ESC4, pystr, end - 5, state);
+                            raise_errmsg(ERR_STRING_ESC4, pystr, end - 5, state);
                             goto bail;
                         }
                     }
@@ -1354,7 +1347,8 @@ py_scanstring(PyObject* self UNUSED, PyObject *args)
     /* Using a bytes input is unsupported for scanning in Python 3.
        It is coerced to str in the decoder before it gets here. */
     else if (PyString_Check(pystr)) {
-        rval = scanstring_str(pystr, end, encoding, strict, &next_end);
+        rval = scanstring_str(pystr, end, encoding, strict, &next_end,
+                              get_speedups_state(self));
     }
 #endif
     else {
@@ -1461,6 +1455,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
     Returns a new PyObject (usually a dict, but object_hook or
     object_pairs_hook can change that)
     */
+    _speedups_state *state = get_speedups_state(s->module_ref);
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
     PyObject *rval = NULL;
@@ -1495,10 +1490,10 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 
             /* read key */
             if (str[idx] != '"') {
-                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx);
+                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
                 goto bail;
             }
-            key = scanstring_str(pystr, idx + 1, encoding, s->strict, &next_idx);
+            key = scanstring_str(pystr, idx + 1, encoding, s->strict, &next_idx, state);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1519,7 +1514,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             /* skip whitespace between key and : delimiter, read :, skip whitespace */
             while (idx <= end_idx && IS_WHITESPACE(str[idx])) idx++;
             if (idx > end_idx || str[idx] != ':') {
-                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
+                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1560,7 +1555,7 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 break;
             }
             else if (str[idx] != ',') {
-                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx);
+                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1570,16 +1565,16 @@ _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx);
+            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
             goto bail;
         }
     }
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || str[idx] != '}') {
         if (did_parse) {
-            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx);
+            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
         } else {
-            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
+            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, state);
         }
         goto bail;
     }
@@ -1624,7 +1619,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
     Returns a new PyObject (usually a dict, but object_hook can change that)
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
@@ -1660,10 +1655,10 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
             /* read key */
             if (PyUnicode_READ(kind, str, idx) != '"') {
-                raise_errmsg_impl(ERR_OBJECT_PROPERTY, pystr, idx, _st);
+                raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
                 goto bail;
             }
-            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx, _st);
+            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx, state);
             if (key == NULL)
                 goto bail;
             memokey = PyDict_GetItemWithError(s->memo, key);
@@ -1685,7 +1680,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                whitespace */
             while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
             if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
-                raise_errmsg_impl(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, _st);
+                raise_errmsg(ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1727,7 +1722,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg_impl(ERR_OBJECT_DELIMITER, pystr, idx, _st);
+                raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1737,7 +1732,7 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg_impl(ERR_OBJECT_PROPERTY, pystr, idx, _st);
+            raise_errmsg(ERR_OBJECT_PROPERTY, pystr, idx, state);
             goto bail;
         }
     }
@@ -1745,9 +1740,9 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     /* verify that idx < end_idx, str[idx] should be '}' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
         if (did_parse) {
-            raise_errmsg_impl(ERR_OBJECT_DELIMITER, pystr, idx, _st);
+            raise_errmsg(ERR_OBJECT_DELIMITER, pystr, idx, state);
         } else {
-            raise_errmsg_impl(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, _st);
+            raise_errmsg(ERR_OBJECT_PROPERTY_FIRST, pystr, idx, state);
         }
         goto bail;
     }
@@ -1792,6 +1787,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
 
     Returns a new PyList
     */
+    _speedups_state *state = get_speedups_state(s->module_ref);
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
     PyObject *val = NULL;
@@ -1829,7 +1825,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
                 break;
             }
             else if (str[idx] != ',') {
-                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx);
+                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1839,7 +1835,7 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx);
+            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
             goto bail;
         }
     }
@@ -1847,9 +1843,9 @@ _parse_array_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || str[idx] != ']') {
         if (PyList_GET_SIZE(rval)) {
-            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx);
+            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
         } else {
-            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx);
+            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx, state);
         }
         goto bail;
     }
@@ -1872,7 +1868,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
 
     Returns a new PyList
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -1911,7 +1907,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
                 break;
             }
             else if (PyUnicode_READ(kind, str, idx) != ',') {
-                raise_errmsg_impl(ERR_ARRAY_DELIMITER, pystr, idx, _st);
+                raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
                 goto bail;
             }
             idx++;
@@ -1921,7 +1917,7 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
             trailing_delimiter = 1;
         }
         if (trailing_delimiter) {
-            raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx, _st);
+            raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
             goto bail;
         }
     }
@@ -1929,9 +1925,9 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
     /* verify that idx < end_idx, str[idx] should be ']' */
     if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
         if (PyList_GET_SIZE(rval)) {
-            raise_errmsg_impl(ERR_ARRAY_DELIMITER, pystr, idx, _st);
+            raise_errmsg(ERR_ARRAY_DELIMITER, pystr, idx, state);
         } else {
-            raise_errmsg_impl(ERR_ARRAY_VALUE_FIRST, pystr, idx, _st);
+            raise_errmsg(ERR_ARRAY_VALUE_FIRST, pystr, idx, state);
         }
         goto bail;
     }
@@ -1957,7 +1953,7 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
     */
     PyObject *rval;
     if (s->parse_constant == Py_None) {
-        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx,
+        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx,
                           get_speedups_state(s->module_ref));
         return NULL;
     }
@@ -1982,6 +1978,7 @@ _match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssiz
         PyInt, PyLong, or PyFloat.
         May return other types if parse_int or parse_float are set
     */
+    _speedups_state *state = get_speedups_state(s->module_ref);
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t end_idx = PyString_GET_SIZE(pystr) - 1;
     Py_ssize_t idx = start;
@@ -1992,7 +1989,7 @@ _match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssiz
     /* read a sign if it's there, make sure it's not the end of the string */
     if (str[idx] == '-') {
         if (idx >= end_idx) {
-            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start);
+            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
             return NULL;
         }
         idx++;
@@ -2009,7 +2006,7 @@ _match_number_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssiz
     }
     /* no integer digits, error */
     else {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start);
+        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
         return NULL;
     }
 
@@ -2089,7 +2086,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
         PyInt, PyLong, or PyFloat.
         May return other types if parse_int or parse_float are set
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -2102,7 +2099,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     /* read a sign if it's there, make sure it's not the end of the string */
     if (PyUnicode_READ(kind, str, idx) == '-') {
         if (idx >= end_idx) {
-            raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, start, _st);
+            raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
             return NULL;
         }
         idx++;
@@ -2122,7 +2119,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
     }
     else {
         /* no integer digits, error */
-        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, start, _st);
+        raise_errmsg(ERR_EXPECTING_VALUE, pystr, start, state);
         return NULL;
     }
 
@@ -2200,22 +2197,21 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
 
     Returns a new PyObject representation of the term.
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t length = PyString_GET_SIZE(pystr);
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx);
+        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
         return NULL;
     }
     switch (str[idx]) {
         case '"':
             /* string */
             rval = scanstring_str(pystr, idx + 1,
-                PyString_AS_STRING(s->encoding),
-                s->strict,
-                next_idx_ptr);
+                                  PyString_AS_STRING(s->encoding),
+                                  s->strict, next_idx_ptr, state);
             break;
         case '{':
             /* object */
@@ -2266,7 +2262,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case 'N':
             /* NaN */
             if ((idx + 2 < length) && str[idx + 1] == 'a' && str[idx + 2] == 'N') {
-                rval = _parse_constant(s, pystr, _st->JSON_NaN, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_NaN, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2274,7 +2270,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case 'I':
             /* Infinity */
             if ((idx + 7 < length) && str[idx + 1] == 'n' && str[idx + 2] == 'f' && str[idx + 3] == 'i' && str[idx + 4] == 'n' && str[idx + 5] == 'i' && str[idx + 6] == 't' && str[idx + 7] == 'y') {
-                rval = _parse_constant(s, pystr, _st->JSON_Infinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_Infinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2282,7 +2278,7 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
         case '-':
             /* -Infinity */
             if ((idx + 8 < length) && str[idx + 1] == 'I' && str[idx + 2] == 'n' && str[idx + 3] == 'f' && str[idx + 4] == 'i' && str[idx + 5] == 'n' && str[idx + 6] == 'i' && str[idx + 7] == 't' && str[idx + 8] == 'y') {
-                rval = _parse_constant(s, pystr, _st->JSON_NegInfinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_NegInfinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2308,21 +2304,21 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 
     Returns a new PyObject representation of the term.
     */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t length = PyUnicode_GET_LENGTH(pystr);
     PyObject *rval = NULL;
     int fallthrough = 0;
     if (idx < 0 || idx >= length) {
-        raise_errmsg_impl(ERR_EXPECTING_VALUE, pystr, idx, _st);
+        raise_errmsg(ERR_EXPECTING_VALUE, pystr, idx, state);
         return NULL;
     }
     switch (PyUnicode_READ(kind, str, idx)) {
         case '"':
             /* string */
             rval = scanstring_unicode(pystr, idx + 1, s->strict,
-                                      next_idx_ptr, _st);
+                                      next_idx_ptr, state);
             break;
         case '{':
             /* object */
@@ -2385,7 +2381,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
             if ((idx + 2 < length) &&
                 PyUnicode_READ(kind, str, idx + 1) == 'a' &&
                 PyUnicode_READ(kind, str, idx + 2) == 'N') {
-                rval = _parse_constant(s, pystr, _st->JSON_NaN, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_NaN, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2400,7 +2396,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 PyUnicode_READ(kind, str, idx + 5) == 'i' &&
                 PyUnicode_READ(kind, str, idx + 6) == 't' &&
                 PyUnicode_READ(kind, str, idx + 7) == 'y') {
-                rval = _parse_constant(s, pystr, _st->JSON_Infinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_Infinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2416,7 +2412,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 PyUnicode_READ(kind, str, idx + 6) == 'i' &&
                 PyUnicode_READ(kind, str, idx + 7) == 't' &&
                 PyUnicode_READ(kind, str, idx + 8) == 'y') {
-                rval = _parse_constant(s, pystr, _st->JSON_NegInfinity, idx, next_idx_ptr);
+                rval = _parse_constant(s, pystr, state->JSON_NegInfinity, idx, next_idx_ptr);
             }
             else
                 fallthrough = 1;
@@ -2784,8 +2780,8 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (is_true < 0)
             goto bail;
         if (is_true) {
-            _speedups_state *_st = get_speedups_state(s->module_ref);
-            item_sort_key = _st->JSON_itemgetter0;
+            _speedups_state *state = get_speedups_state(s->module_ref);
+            item_sort_key = state->JSON_itemgetter0;
             if (!item_sort_key)
                 goto bail;
         }
@@ -2827,15 +2823,17 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     Py_ssize_t indent_level;
     PyEncoderObject *s;
     JSON_Accu rval;
+    _speedups_state *state;
     int encode_rv;
 #if PY_VERSION_HEX < 0x030D0000
     assert(PyEncoder_Check(self));
 #endif
     s = (PyEncoderObject *)self;
+    state = get_speedups_state(s->module_ref);
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&:_iterencode", kwlist,
         &obj, _convertPyInt_AsSsize_t, &indent_level))
         return NULL;
-    if (JSON_Accu_Init(&rval, get_speedups_state(s->module_ref)))
+    if (JSON_Accu_Init(&rval))
         return NULL;
     Py_BEGIN_CRITICAL_SECTION(self);
     encode_rv = encoder_listencode_obj(s, &rval, obj, indent_level);
@@ -2844,7 +2842,7 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
         JSON_Accu_Destroy(&rval);
         return NULL;
     }
-    return JSON_Accu_FinishAsList(&rval);
+    return JSON_Accu_FinishAsList(&rval, state);
 }
 
 static PyObject *
@@ -2873,7 +2871,7 @@ static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a PyFloat */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         if (!s->allow_or_ignore_nan) {
@@ -2881,20 +2879,20 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
             return NULL;
         }
         if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
-            return _encoded_const(Py_None, _st);
+            return _encoded_const(Py_None, state);
         }
         /* JSON_ALLOW_NAN is set */
         else if (i > 0) {
-            Py_INCREF(_st->JSON_Infinity);
-            return _st->JSON_Infinity;
+            Py_INCREF(state->JSON_Infinity);
+            return state->JSON_Infinity;
         }
         else if (i < 0) {
-            Py_INCREF(_st->JSON_NegInfinity);
-            return _st->JSON_NegInfinity;
+            Py_INCREF(state->JSON_NegInfinity);
+            return state->JSON_NegInfinity;
         }
         else {
-            Py_INCREF(_st->JSON_NaN);
-            return _st->JSON_NaN;
+            Py_INCREF(state->JSON_NaN);
+            return state->JSON_NaN;
         }
     }
     /* Use a better float format here? */
@@ -2940,10 +2938,10 @@ encoder_encode_string(PyEncoderObject *s, PyObject *obj)
 }
 
 static int
-_steal_accumulate(JSON_Accu *accu, PyObject *stolen)
+_steal_accumulate(JSON_Accu *accu, PyObject *stolen, _speedups_state *state)
 {
     /* Append stolen and then decrement its reference count */
-    int rval = JSON_Accu_Accumulate(accu, stolen);
+    int rval = JSON_Accu_Accumulate(accu, stolen, state);
     Py_DECREF(stolen);
     return rval;
 }
@@ -2952,21 +2950,21 @@ static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level)
 {
     /* Encode Python object obj to a JSON term, rval is a PyList */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     int rv = -1;
     do {
         PyObject *newobj;
         if (obj == Py_None || obj == Py_True || obj == Py_False) {
-            PyObject *cstr = _encoded_const(obj, _st);
+            PyObject *cstr = _encoded_const(obj, state);
             if (cstr != NULL)
-                rv = _steal_accumulate(rval, cstr);
+                rv = _steal_accumulate(rval, cstr, state);
         }
         else if ((PyBytes_Check(obj) && s->encoding != NULL) ||
                  PyUnicode_Check(obj))
         {
             PyObject *encoded = encoder_encode_string(s, obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded);
+                rv = _steal_accumulate(rval, encoded, state);
         }
         else if (PyInt_Check(obj) || PyLong_Check(obj)) {
             PyObject *encoded;
@@ -2988,13 +2986,13 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
                 encoded = maybe_quote_bigint(s, encoded, obj);
                 if (encoded == NULL)
                     break;
-                rv = _steal_accumulate(rval, encoded);
+                rv = _steal_accumulate(rval, encoded, state);
             }
         }
         else if (PyFloat_Check(obj)) {
             PyObject *encoded = encoder_encode_float(s, obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded);
+                rv = _steal_accumulate(rval, encoded, state);
         }
         else if (s->for_json && _call_json_method(obj, FOR_JSON_METHOD_NAME, &newobj)) {
             if (newobj == NULL) {
@@ -3044,16 +3042,16 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
         else if (s->use_decimal && PyObject_TypeCheck(obj, (PyTypeObject *)s->Decimal)) {
             PyObject *encoded = PyObject_Str(obj);
             if (encoded != NULL)
-                rv = _steal_accumulate(rval, encoded);
+                rv = _steal_accumulate(rval, encoded, state);
         }
         else {
-            int raw = is_raw_json(obj, _st);
+            int raw = is_raw_json(obj, state);
             if (raw < 0)
                 break;
             if (raw) {
                 PyObject *encoded = PyObject_GetAttrString(obj, "encoded_json");
                 if (encoded != NULL)
-                    rv = _steal_accumulate(rval, encoded);
+                    rv = _steal_accumulate(rval, encoded, state);
             }
             else {
             PyObject *ident = NULL;
@@ -3121,7 +3119,7 @@ static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level)
 {
     /* Encode Python dict dct a JSON term */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PyObject *kstr = NULL;
     PyObject *ident = NULL;
     PyObject *iter = NULL;
@@ -3131,7 +3129,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
     Py_ssize_t idx;
 
     if (PyDict_Size(dct) == 0)
-        return JSON_Accu_Accumulate(rval, _st->JSON_empty_dict);
+        return JSON_Accu_Accumulate(rval, state->JSON_empty_dict, state);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3149,7 +3147,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
         }
     }
 
-    if (JSON_Accu_Accumulate(rval, _st->JSON_open_dict))
+    if (JSON_Accu_Accumulate(rval, state->JSON_open_dict, state))
         goto bail;
 
     if (s->indent != Py_None) {
@@ -3190,7 +3188,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             continue;
         }
         if (idx) {
-            if (JSON_Accu_Accumulate(rval, s->item_separator))
+            if (JSON_Accu_Accumulate(rval, s->item_separator, state))
                 goto bail;
         }
         /*
@@ -3212,11 +3210,11 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             if (PyDict_SetItem(s->key_memo, key, encoded))
                 goto bail;
         }
-        if (JSON_Accu_Accumulate(rval, encoded)) {
+        if (JSON_Accu_Accumulate(rval, encoded, state)) {
             goto bail;
         }
         Py_CLEAR(encoded);
-        if (JSON_Accu_Accumulate(rval, s->key_separator))
+        if (JSON_Accu_Accumulate(rval, s->key_separator, state))
             goto bail;
         if (encoder_listencode_obj(s, rval, value, indent_level))
             goto bail;
@@ -3238,7 +3236,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, _st->JSON_close_dict))
+    if (JSON_Accu_Accumulate(rval, state->JSON_close_dict, state))
         goto bail;
     return 0;
 
@@ -3257,7 +3255,7 @@ static int
 encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_ssize_t indent_level)
 {
     /* Encode Python list seq to a JSON term */
-    _speedups_state *_st = get_speedups_state(s->module_ref);
+    _speedups_state *state = get_speedups_state(s->module_ref);
     PyObject *ident = NULL;
     PyObject *iter = NULL;
     PyObject *obj = NULL;
@@ -3269,7 +3267,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (is_true == -1)
         return -1;
     else if (is_true == 0)
-        return JSON_Accu_Accumulate(rval, _st->JSON_empty_array);
+        return JSON_Accu_Accumulate(rval, state->JSON_empty_array, state);
 
     if (s->markers != Py_None) {
         int has_key;
@@ -3291,7 +3289,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     if (iter == NULL)
         goto bail;
 
-    if (JSON_Accu_Accumulate(rval, _st->JSON_open_array))
+    if (JSON_Accu_Accumulate(rval, state->JSON_open_array, state))
         goto bail;
     if (s->indent != Py_None) {
         /* TODO: DOES NOT RUN */
@@ -3304,7 +3302,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
     }
     while ((obj = PyIter_Next(iter))) {
         if (i) {
-            if (JSON_Accu_Accumulate(rval, s->item_separator))
+            if (JSON_Accu_Accumulate(rval, s->item_separator, state))
                 goto bail;
         }
         if (encoder_listencode_obj(s, rval, obj, indent_level))
@@ -3327,7 +3325,7 @@ encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_s
             yield '\n' + (_indent * _current_indent_level)
         */
     }
-    if (JSON_Accu_Accumulate(rval, _st->JSON_close_array))
+    if (JSON_Accu_Accumulate(rval, state->JSON_close_array, state))
         goto bail;
     return 0;
 

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1527,7 +1527,6 @@ _match_number_int_fast_str(PyScannerObject *s, PyObject *numstr)
 #endif
 #define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_unicode(ns)
 #define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_unicode(s, ns)
-#define JSON_SCAN_MAYBE_ENCODING_DECL  ((void)0)
 #include "_speedups_scan.h"
 
 /* -- Generate the corresponding _str variants on Python 2. -- */
@@ -1538,12 +1537,12 @@ _match_number_int_fast_str(PyScannerObject *s, PyObject *numstr)
     Py_ssize_t end_idx = PyString_GET_SIZE(p) - 1
 #define JSON_SCAN_READ(i) ((unsigned char)str[(i)])
 #define JSON_SCAN_SCANSTRING_CALL(pos, nextp) \
-    scanstring_str(state, pystr, (pos), encoding, s->strict, (nextp))
+    scanstring_str(state, pystr, (pos), \
+                   PyString_AS_STRING(s->encoding), s->strict, (nextp))
 #define JSON_SCAN_NUMSTR_CREATE(sidx, eidx) \
     PyString_FromStringAndSize(&str[(sidx)], (eidx) - (sidx))
 #define JSON_SCAN_PARSE_FLOAT_FAST(ns) _match_number_float_fast_str(ns)
 #define JSON_SCAN_PARSE_INT_FAST(ns)   _match_number_int_fast_str(s, ns)
-#define JSON_SCAN_MAYBE_ENCODING_DECL  char *encoding = PyString_AS_STRING(s->encoding)
 #include "_speedups_scan.h"
 #endif /* PY_MAJOR_VERSION < 3 */
 

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -312,7 +312,7 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
 static PyObject *
 _encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false);
 static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError);
+raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError);
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -334,12 +334,20 @@ import_dependency(char *module_name, char *attr_name);
 
 /* Short aliases for helpers that take state-derived arguments. Defined
    once for all Python versions now that the state layout is unified. */
-#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg(msg, s, end, jde)
+#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg_impl(msg, s, end, jde)
 #define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj, sn, st, sf)
 #define IS_RAW_JSON(obj, rjt) is_raw_json(obj, rjt)
 #define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst, eu)
 #define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
     scanstring_unicode(pystr, end, strict, next_end_ptr, eu, jde)
+
+#if PY_MAJOR_VERSION < 3
+/* Python 2 call sites use a 3-arg form without threading state
+   through the scanner functions; resolve JSONDecodeError from the
+   static state at the call site. */
+#define raise_errmsg(msg, s, end) \
+    raise_errmsg_impl(msg, s, end, _speedups_static_state.JSONDecodeError)
+#endif
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
@@ -862,7 +870,7 @@ bail:
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
 static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
+raise_errmsg_impl(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
 {
     PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
     if (exc) {
@@ -2221,6 +2229,10 @@ scan_once_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *n
 
     Returns a new PyObject representation of the term.
     */
+    _speedups_state *_st = get_speedups_state(s->module_ref);
+    PyObject *JSON_NaN = _st->JSON_NaN;
+    PyObject *JSON_Infinity = _st->JSON_Infinity;
+    PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
     char *str = PyString_AS_STRING(pystr);
     Py_ssize_t length = PyString_GET_SIZE(pystr);
     PyObject *rval = NULL;

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -83,19 +83,24 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
 
 #define DEFAULT_ENCODING "utf-8"
 
-#if PY_VERSION_HEX >= 0x030D0000
-/* Module state for Python 3.13+ (heap types).
-   Type objects live here for proper GC and lifecycle management.
-   String constants remain as file-scope globals because they are
-   interned / immutable and safe to share across threads. */
+/* Unified module state.
+   On Python 3.13+ this is stored per-module (PEP 489) so that each
+   subinterpreter gets its own copy. On older Python versions a single
+   static instance is shared by the whole process. Either way, code
+   accesses it via get_speedups_state(module_ref) so that call sites
+   look identical on all versions. */
 typedef struct {
+#if PY_VERSION_HEX >= 0x030D0000
     PyObject *PyScannerType;
     PyObject *PyEncoderType;
-    /* Constants – per-module state instead of file-scope globals */
+#endif
     PyObject *JSON_Infinity;
     PyObject *JSON_NegInfinity;
     PyObject *JSON_NaN;
     PyObject *JSON_EmptyUnicode;
+#if PY_MAJOR_VERSION < 3
+    PyObject *JSON_EmptyStr;
+#endif
     PyObject *JSON_s_null;
     PyObject *JSON_s_true;
     PyObject *JSON_s_false;
@@ -111,19 +116,16 @@ typedef struct {
     PyObject *JSONDecodeError;
 } _speedups_state;
 
-static inline _speedups_state *
-get_speedups_state(PyObject *module)
-{
-    void *state = PyModule_GetState(module);
-    assert(state != NULL);
-    return (_speedups_state *)state;
-}
-
+#if PY_VERSION_HEX >= 0x030D0000
 /* Forward declaration - defined later with multi-phase init */
 static struct PyModuleDef moduledef;
-#endif /* PY_VERSION_HEX >= 0x030D0000 */
-
-#if PY_VERSION_HEX < 0x030D0000
+#else
+/* Pre-3.13: a single static state instance serves the whole process,
+   and a borrowed reference to the module object so that Scanner and
+   Encoder instances can store module_ref uniformly. The module object
+   is kept alive by sys.modules for the entire interpreter lifetime. */
+static _speedups_state _speedups_static_state;
+static PyObject *_speedups_module = NULL;  /* borrowed */
 static PyTypeObject PyScannerType;
 static PyTypeObject PyEncoderType;
 #define PyScanner_Check(op) PyObject_TypeCheck(op, &PyScannerType)
@@ -132,44 +134,32 @@ static PyTypeObject PyEncoderType;
 #define PyEncoder_CheckExact(op) (Py_TYPE(op) == &PyEncoderType)
 #endif
 
+static inline _speedups_state *
+get_speedups_state(PyObject *module)
+{
+#if PY_VERSION_HEX >= 0x030D0000
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_speedups_state *)state;
+#else
+    (void)module;
+    return &_speedups_static_state;
+#endif
+}
+
 #define JSON_ALLOW_NAN 1
 #define JSON_IGNORE_NAN 2
-
-#if PY_VERSION_HEX < 0x030D0000
-static PyObject *JSON_Infinity = NULL;
-static PyObject *JSON_NegInfinity = NULL;
-static PyObject *JSON_NaN = NULL;
-static PyObject *JSON_EmptyUnicode = NULL;
-#if PY_MAJOR_VERSION < 3
-static PyObject *JSON_EmptyStr = NULL;
-#endif
-
-/* Interned string constants, initialized in init_constants().
-   Previously lazily initialized in individual functions, which
-   is a data race under free-threaded Python (PEP 703). */
-static PyObject *JSON_s_null = NULL;
-static PyObject *JSON_s_true = NULL;
-static PyObject *JSON_s_false = NULL;
-static PyObject *JSON_open_dict = NULL;
-static PyObject *JSON_close_dict = NULL;
-static PyObject *JSON_empty_dict = NULL;
-static PyObject *JSON_open_array = NULL;
-static PyObject *JSON_close_array = NULL;
-static PyObject *JSON_empty_array = NULL;
-static PyObject *JSON_sortargs = NULL;
-static PyObject *JSON_itemgetter0 = NULL;
-#endif /* PY_VERSION_HEX < 0x030D0000 */
 
 typedef struct {
     PyObject *large_strings;  /* A list of previously accumulated large strings */
     PyObject *small_strings;  /* Pending small strings */
-#if PY_VERSION_HEX >= 0x030D0000
+#if PY_MAJOR_VERSION >= 3
     PyObject *empty_unicode;  /* Borrowed ref to state->JSON_EmptyUnicode */
 #endif
 } JSON_Accu;
 
 static int
-JSON_Accu_Init(JSON_Accu *acc);
+JSON_Accu_Init(JSON_Accu *acc, _speedups_state *state);
 static int
 JSON_Accu_Accumulate(JSON_Accu *acc, PyObject *unicode);
 static PyObject *
@@ -194,9 +184,7 @@ JSON_Accu_Destroy(JSON_Accu *acc);
 
 typedef struct _PyScannerObject {
     PyObject_HEAD
-#if PY_VERSION_HEX >= 0x030D0000
     PyObject *module_ref;
-#endif
     PyObject *encoding;
     PyObject *strict_bool;
     int strict;
@@ -221,9 +209,7 @@ static PyMemberDef scanner_members[] = {
 
 typedef struct _PyEncoderObject {
     PyObject_HEAD
-#if PY_VERSION_HEX >= 0x030D0000
     PyObject *module_ref;
-#endif
     PyObject *markers;
     PyObject *defaultfn;
     PyObject *encoder;
@@ -268,13 +254,8 @@ static PyMemberDef encoder_members[] = {
     {NULL}
 };
 
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 join_list_unicode(PyObject *lst, PyObject *empty_unicode);
-#else
-static PyObject *
-join_list_unicode(PyObject *lst);
-#endif
 static PyObject *
 JSON_ParseEncoding(PyObject *encoding);
 static PyObject *
@@ -299,14 +280,9 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
 static PyObject *
 _parse_object_str(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 #endif
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
                    PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError);
-#else
-static PyObject *
-scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr);
-#endif
 static PyObject *
 scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
 static PyObject *
@@ -323,13 +299,8 @@ static void
 encoder_dealloc(PyObject *self);
 static int
 encoder_clear(PyObject *self);
-#if PY_VERSION_HEX >= 0x030D0000
 static int
 is_raw_json(PyObject *obj, PyObject *RawJSONType);
-#else
-static int
-is_raw_json(PyObject *obj);
-#endif
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key);
 static int
@@ -338,17 +309,10 @@ static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level);
 static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level);
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 _encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false);
 static void
 raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError);
-#else
-static PyObject *
-_encoded_const(PyObject *obj);
-static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end);
-#endif
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj);
 static int
@@ -362,47 +326,26 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj);
 #if PY_VERSION_HEX < 0x030D0000
 static PyObject *
 moduleinit(void);
-static int
-init_constants(void);
 #endif
+static int
+init_speedups_state(_speedups_state *state, PyObject *module);
 static PyObject *
 import_dependency(char *module_name, char *attr_name);
 
-/* Convenience macros for dual-signature utility functions.
-   On 3.13+ these pass per-module-state objects; on older versions
-   the functions use file-scope globals and the extra args are ignored. */
-#if PY_VERSION_HEX >= 0x030D0000
+/* Short aliases for helpers that take state-derived arguments. Defined
+   once for all Python versions now that the state layout is unified. */
 #define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg(msg, s, end, jde)
 #define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj, sn, st, sf)
 #define IS_RAW_JSON(obj, rjt) is_raw_json(obj, rjt)
 #define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst, eu)
 #define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
     scanstring_unicode(pystr, end, strict, next_end_ptr, eu, jde)
-#else
-#define RAISE_ERRMSG(msg, s, end, jde) raise_errmsg(msg, s, end)
-#define ENCODED_CONST(obj, sn, st, sf) _encoded_const(obj)
-#define IS_RAW_JSON(obj, rjt) is_raw_json(obj)
-#define JOIN_LIST_UNICODE(lst, eu) join_list_unicode(lst)
-#define SCANSTRING_UNICODE(pystr, end, strict, next_end_ptr, eu, jde) \
-    scanstring_unicode(pystr, end, strict, next_end_ptr)
-#endif
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
 
 #define MIN_EXPANSION 6
 
-#if PY_VERSION_HEX < 0x030D0000
-static PyObject* RawJSONType = NULL;
-static int
-is_raw_json(PyObject *obj)
-{
-    int r = PyObject_IsInstance(obj, RawJSONType);
-    if (r < 0)
-        return -1;
-    return r;
-}
-#else
 static int
 is_raw_json(PyObject *obj, PyObject *RawJSONType)
 {
@@ -411,16 +354,20 @@ is_raw_json(PyObject *obj, PyObject *RawJSONType)
         return -1;
     return r;
 }
-#endif
 
 static int
-JSON_Accu_Init(JSON_Accu *acc)
+JSON_Accu_Init(JSON_Accu *acc, _speedups_state *state)
 {
     /* Lazily allocated */
     acc->large_strings = NULL;
     acc->small_strings = PyList_New(0);
     if (acc->small_strings == NULL)
         return -1;
+#if PY_MAJOR_VERSION >= 3
+    acc->empty_unicode = state->JSON_EmptyUnicode;  /* borrowed */
+#else
+    (void)state;
+#endif
     return 0;
 }
 
@@ -436,13 +383,11 @@ flush_accumulator(JSON_Accu *acc)
             if (acc->large_strings == NULL)
                 return -1;
         }
-#if PY_VERSION_HEX >= 0x030D0000
+#if PY_MAJOR_VERSION >= 3
         joined = join_list_unicode(acc->small_strings, acc->empty_unicode);
-#elif PY_MAJOR_VERSION >= 3
-        joined = join_list_unicode(acc->small_strings);
-#else /* PY_MAJOR_VERSION >= 3 */
+#else
         joined = join_list_string(acc->small_strings);
-#endif /* PY_MAJOR_VERSION < 3 */
+#endif
         if (joined == NULL)
             return -1;
         if (PyList_SetSlice(acc->small_strings, 0, nsmall, NULL)) {
@@ -761,12 +706,10 @@ ascii_escape_str(PyObject *pystr)
 static PyObject *
 encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 {
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_s_null = _st->JSON_s_null;
     PyObject *JSON_s_true = _st->JSON_s_true;
     PyObject *JSON_s_false = _st->JSON_s_false;
-#endif
     if (PyUnicode_Check(key)) {
         Py_INCREF(key);
         return key;
@@ -828,10 +771,8 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
 static PyObject *
 encoder_dict_iteritems(PyEncoderObject *s, PyObject *dct)
 {
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_sortargs = _st->JSON_sortargs;
-#endif
     PyObject *items;
     PyObject *iter = NULL;
     PyObject *lst = NULL;
@@ -920,18 +861,6 @@ bail:
 }
 
 /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
-#if PY_VERSION_HEX < 0x030D0000
-static PyObject *JSONDecodeError = NULL;
-static void
-raise_errmsg(char *msg, PyObject *s, Py_ssize_t end)
-{
-    PyObject *exc = PyObject_CallFunction(JSONDecodeError, "(zOO&)", msg, s, _convertPyInt_FromSsize_t, &end);
-    if (exc) {
-        PyErr_SetObject(JSONDecodeError, exc);
-        Py_DECREF(exc);
-    }
-}
-#else
 static void
 raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
 {
@@ -941,34 +870,22 @@ raise_errmsg(char *msg, PyObject *s, Py_ssize_t end, PyObject *JSONDecodeError)
         Py_DECREF(exc);
     }
 }
-#endif
 
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 join_list_unicode(PyObject *lst, PyObject *empty_unicode)
 {
     /* return u''.join(lst) */
     return PyUnicode_Join(empty_unicode, lst);
 }
-#else
-static PyObject *
-join_list_unicode(PyObject *lst)
-{
-    /* return u''.join(lst) */
-    return PyUnicode_Join(JSON_EmptyUnicode, lst);
-}
-#endif
 
-#if PY_MAJOR_VERSION >= 3
-#define join_list_string join_list_unicode
-#else /* PY_MAJOR_VERSION >= 3 */
+#if PY_MAJOR_VERSION < 3
 static PyObject *
 join_list_string(PyObject *lst)
 {
     /* return ''.join(lst) */
     static PyObject *joinfn = NULL;
     if (joinfn == NULL) {
-        joinfn = PyObject_GetAttrString(JSON_EmptyStr, "join");
+        joinfn = PyObject_GetAttrString(_speedups_static_state.JSON_EmptyStr, "join");
         if (joinfn == NULL)
             return NULL;
     }
@@ -1204,7 +1121,7 @@ scanstring_str(PyObject *pystr, Py_ssize_t end, char *encoding, int strict, Py_s
         if (chunk != NULL)
             rval = chunk;
         else {
-            rval = JSON_EmptyStr;
+            rval = _speedups_static_state.JSON_EmptyStr;
             Py_INCREF(rval);
         }
     }
@@ -1227,14 +1144,9 @@ bail:
 }
 #endif /* PY_MAJOR_VERSION < 3 */
 
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr,
                    PyObject *JSON_EmptyUnicode, PyObject *JSONDecodeError)
-#else
-static PyObject *
-scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr)
-#endif
 {
     /* Read the JSON string from PyUnicode pystr.
     end is the index of the first character after the quote.
@@ -1448,15 +1360,11 @@ py_scanstring(PyObject* self UNUSED, PyObject *args)
     if (PyUnicode_Check(pystr)) {
         if (PyUnicode_READY(pystr))
             return NULL;
-#if PY_VERSION_HEX >= 0x030D0000
         {
             _speedups_state *_st = get_speedups_state(self);
             rval = scanstring_unicode(pystr, end, strict, &next_end,
                                       _st->JSON_EmptyUnicode, _st->JSONDecodeError);
         }
-#else
-        rval = scanstring_unicode(pystr, end, strict, &next_end);
-#endif
     }
 #if PY_MAJOR_VERSION < 3
     /* Using a bytes input is unsupported for scanning in Python 3.
@@ -1519,15 +1427,14 @@ scanner_dealloc(PyObject *self)
 static int
 scanner_traverse(PyObject *self, visitproc visit, void *arg)
 {
-    PyScannerObject *s;
-#if PY_VERSION_HEX < 0x030D0000
+    PyScannerObject *s = (PyScannerObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    /* Heap types must visit their type for GC. */
+    Py_VISIT(Py_TYPE(self));
+#else
     assert(PyScanner_Check(self));
 #endif
-    s = (PyScannerObject *)self;
-#if PY_VERSION_HEX >= 0x030D0000
-    Py_VISIT(Py_TYPE(self));
     Py_VISIT(s->module_ref);
-#endif
     Py_VISIT(s->encoding);
     Py_VISIT(s->strict_bool);
     Py_VISIT(s->object_hook);
@@ -1542,14 +1449,11 @@ scanner_traverse(PyObject *self, visitproc visit, void *arg)
 static int
 scanner_clear(PyObject *self)
 {
-    PyScannerObject *s;
+    PyScannerObject *s = (PyScannerObject *)self;
 #if PY_VERSION_HEX < 0x030D0000
     assert(PyScanner_Check(self));
 #endif
-    s = (PyScannerObject *)self;
-#if PY_VERSION_HEX >= 0x030D0000
     Py_CLEAR(s->module_ref);
-#endif
     Py_CLEAR(s->encoding);
     Py_CLEAR(s->strict_bool);
     Py_CLEAR(s->object_hook);
@@ -1736,11 +1640,9 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
 
     Returns a new PyObject (usually a dict, but object_hook can change that)
     */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
     PyObject *JSONDecodeError = _st->JSONDecodeError;
-#endif
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
@@ -1988,10 +1890,8 @@ _parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssi
 
     Returns a new PyList
     */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSONDecodeError = _st->JSONDecodeError;
-#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -2074,10 +1974,8 @@ _parse_constant(PyScannerObject *s, PyObject *pystr, PyObject *constant, Py_ssiz
 
     Returns the result of parse_constant
     */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSONDecodeError = _st->JSONDecodeError;
-#endif
     PyObject *rval;
     if (s->parse_constant == Py_None) {
         RAISE_ERRMSG(ERR_EXPECTING_VALUE, pystr, idx, JSONDecodeError);
@@ -2211,10 +2109,8 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
         PyInt, PyLong, or PyFloat.
         May return other types if parse_int or parse_float are set
     */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSONDecodeError = _st->JSONDecodeError;
-#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
@@ -2432,14 +2328,12 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
 
     Returns a new PyObject representation of the term.
     */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_NaN = _st->JSON_NaN;
     PyObject *JSON_Infinity = _st->JSON_Infinity;
     PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
     PyObject *JSON_EmptyUnicode = _st->JSON_EmptyUnicode;
     PyObject *JSONDecodeError = _st->JSONDecodeError;
-#endif
     PY2_UNUSED int kind = PyUnicode_KIND(pystr);
     void *str = PyUnicode_DATA(pystr);
     Py_ssize_t length = PyUnicode_GET_LENGTH(pystr);
@@ -2655,8 +2549,10 @@ scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     s->module_ref = PyType_GetModuleByDef(type, &moduledef);
     if (s->module_ref == NULL)
         goto bail;
-    Py_INCREF(s->module_ref);
+#else
+    s->module_ref = _speedups_module;  /* borrowed */
 #endif
+    Py_INCREF(s->module_ref);
 
     if (s->memo == NULL) {
         s->memo = PyDict_New();
@@ -2818,8 +2714,10 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     s->module_ref = PyType_GetModuleByDef(type, &moduledef);
     if (s->module_ref == NULL)
         goto bail;
-    Py_INCREF(s->module_ref);
+#else
+    s->module_ref = _speedups_module;  /* borrowed */
 #endif
+    Py_INCREF(s->module_ref);
 
     Py_INCREF(markers);
     s->markers = markers;
@@ -2912,12 +2810,8 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (is_true < 0)
             goto bail;
         if (is_true) {
-#if PY_VERSION_HEX >= 0x030D0000
             _speedups_state *_st = get_speedups_state(s->module_ref);
             item_sort_key = _st->JSON_itemgetter0;
-#else
-            item_sort_key = JSON_itemgetter0;
-#endif
             if (!item_sort_key)
                 goto bail;
         }
@@ -2967,14 +2861,8 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&:_iterencode", kwlist,
         &obj, _convertPyInt_AsSsize_t, &indent_level))
         return NULL;
-    if (JSON_Accu_Init(&rval))
+    if (JSON_Accu_Init(&rval, get_speedups_state(s->module_ref)))
         return NULL;
-#if PY_VERSION_HEX >= 0x030D0000
-    {
-        _speedups_state *_st = get_speedups_state(s->module_ref);
-        rval.empty_unicode = _st->JSON_EmptyUnicode;
-    }
-#endif
     Py_BEGIN_CRITICAL_SECTION(self);
     encode_rv = encoder_listencode_obj(s, &rval, obj, indent_level);
     Py_END_CRITICAL_SECTION();
@@ -2985,7 +2873,6 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     return JSON_Accu_FinishAsList(&rval);
 }
 
-#if PY_VERSION_HEX >= 0x030D0000
 static PyObject *
 _encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyObject *JSON_s_false)
 {
@@ -3007,35 +2894,11 @@ _encoded_const(PyObject *obj, PyObject *JSON_s_null, PyObject *JSON_s_true, PyOb
         return NULL;
     }
 }
-#else
-static PyObject *
-_encoded_const(PyObject *obj)
-{
-    /* Return the JSON string representation of None, True, False */
-    if (obj == Py_None) {
-        Py_INCREF(JSON_s_null);
-        return JSON_s_null;
-    }
-    else if (obj == Py_True) {
-        Py_INCREF(JSON_s_true);
-        return JSON_s_true;
-    }
-    else if (obj == Py_False) {
-        Py_INCREF(JSON_s_false);
-        return JSON_s_false;
-    }
-    else {
-        PyErr_SetString(PyExc_ValueError, "not a const");
-        return NULL;
-    }
-}
-#endif
 
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a PyFloat */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_Infinity = _st->JSON_Infinity;
     PyObject *JSON_NegInfinity = _st->JSON_NegInfinity;
@@ -3043,7 +2906,6 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     PyObject *JSON_s_null = _st->JSON_s_null;
     PyObject *JSON_s_true = _st->JSON_s_true;
     PyObject *JSON_s_false = _st->JSON_s_false;
-#endif
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
         if (!s->allow_or_ignore_nan) {
@@ -3122,13 +2984,11 @@ static int
 encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ssize_t indent_level)
 {
     /* Encode Python object obj to a JSON term, rval is a PyList */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_s_null = _st->JSON_s_null;
     PyObject *JSON_s_true = _st->JSON_s_true;
     PyObject *JSON_s_false = _st->JSON_s_false;
     PyObject *RawJSONType = _st->RawJSONType;
-#endif
     int rv = -1;
     do {
         PyObject *newobj;
@@ -3297,12 +3157,10 @@ static int
 encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_ssize_t indent_level)
 {
     /* Encode Python dict dct a JSON term */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_empty_dict = _st->JSON_empty_dict;
     PyObject *JSON_open_dict = _st->JSON_open_dict;
     PyObject *JSON_close_dict = _st->JSON_close_dict;
-#endif
     PyObject *kstr = NULL;
     PyObject *ident = NULL;
     PyObject *iter = NULL;
@@ -3438,12 +3296,10 @@ static int
 encoder_listencode_list(PyEncoderObject *s, JSON_Accu *rval, PyObject *seq, Py_ssize_t indent_level)
 {
     /* Encode Python list seq to a JSON term */
-#if PY_VERSION_HEX >= 0x030D0000
     _speedups_state *_st = get_speedups_state(s->module_ref);
     PyObject *JSON_empty_array = _st->JSON_empty_array;
     PyObject *JSON_open_array = _st->JSON_open_array;
     PyObject *JSON_close_array = _st->JSON_close_array;
-#endif
     PyObject *ident = NULL;
     PyObject *iter = NULL;
     PyObject *obj = NULL;
@@ -3542,15 +3398,14 @@ encoder_dealloc(PyObject *self)
 static int
 encoder_traverse(PyObject *self, visitproc visit, void *arg)
 {
-    PyEncoderObject *s;
-#if PY_VERSION_HEX < 0x030D0000
+    PyEncoderObject *s = (PyEncoderObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    /* Heap types must visit their type for GC. */
+    Py_VISIT(Py_TYPE(self));
+#else
     assert(PyEncoder_Check(self));
 #endif
-    s = (PyEncoderObject *)self;
-#if PY_VERSION_HEX >= 0x030D0000
-    Py_VISIT(Py_TYPE(self));
     Py_VISIT(s->module_ref);
-#endif
     Py_VISIT(s->markers);
     Py_VISIT(s->defaultfn);
     Py_VISIT(s->encoder);
@@ -3573,14 +3428,11 @@ static int
 encoder_clear(PyObject *self)
 {
     /* Deallocate Encoder */
-    PyEncoderObject *s;
+    PyEncoderObject *s = (PyEncoderObject *)self;
 #if PY_VERSION_HEX < 0x030D0000
     assert(PyEncoder_Check(self));
 #endif
-    s = (PyEncoderObject *)self;
-#if PY_VERSION_HEX >= 0x030D0000
     Py_CLEAR(s->module_ref);
-#endif
     Py_CLEAR(s->markers);
     Py_CLEAR(s->defaultfn);
     Py_CLEAR(s->encoder);
@@ -3680,6 +3532,82 @@ static PyMethodDef speedups_methods[] = {
 PyDoc_STRVAR(module_doc,
 "simplejson speedups\n");
 
+/* Shared initializer for per-module state. Used by both module_exec on
+   3.13+ and moduleinit on older versions. Assumes the type fields (on
+   3.13+) have already been populated. */
+static int
+init_speedups_state(_speedups_state *state, PyObject *module)
+{
+    state->JSON_NaN = JSON_InternFromString("NaN");
+    if (state->JSON_NaN == NULL)
+        return -1;
+    state->JSON_Infinity = JSON_InternFromString("Infinity");
+    if (state->JSON_Infinity == NULL)
+        return -1;
+    state->JSON_NegInfinity = JSON_InternFromString("-Infinity");
+    if (state->JSON_NegInfinity == NULL)
+        return -1;
+#if PY_MAJOR_VERSION >= 3
+    state->JSON_EmptyUnicode = PyUnicode_New(0, 127);
+#else
+    state->JSON_EmptyStr = PyString_FromString("");
+    if (state->JSON_EmptyStr == NULL)
+        return -1;
+    state->JSON_EmptyUnicode = PyUnicode_FromUnicode(NULL, 0);
+#endif
+    if (state->JSON_EmptyUnicode == NULL)
+        return -1;
+    state->JSON_s_null = JSON_InternFromString("null");
+    if (state->JSON_s_null == NULL)
+        return -1;
+    state->JSON_s_true = JSON_InternFromString("true");
+    if (state->JSON_s_true == NULL)
+        return -1;
+    state->JSON_s_false = JSON_InternFromString("false");
+    if (state->JSON_s_false == NULL)
+        return -1;
+    state->JSON_open_dict = JSON_InternFromString("{");
+    if (state->JSON_open_dict == NULL)
+        return -1;
+    state->JSON_close_dict = JSON_InternFromString("}");
+    if (state->JSON_close_dict == NULL)
+        return -1;
+    state->JSON_empty_dict = JSON_InternFromString("{}");
+    if (state->JSON_empty_dict == NULL)
+        return -1;
+    state->JSON_open_array = JSON_InternFromString("[");
+    if (state->JSON_open_array == NULL)
+        return -1;
+    state->JSON_close_array = JSON_InternFromString("]");
+    if (state->JSON_close_array == NULL)
+        return -1;
+    state->JSON_empty_array = JSON_InternFromString("[]");
+    if (state->JSON_empty_array == NULL)
+        return -1;
+    state->JSON_sortargs = PyTuple_New(0);
+    if (state->JSON_sortargs == NULL)
+        return -1;
+
+    state->RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
+    if (state->RawJSONType == NULL)
+        return -1;
+    state->JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
+    if (state->JSONDecodeError == NULL)
+        return -1;
+
+    {
+        PyObject *operator_mod = PyImport_ImportModule("operator");
+        if (!operator_mod)
+            return -1;
+        state->JSON_itemgetter0 = PyObject_CallMethod(operator_mod, "itemgetter", "i", 0);
+        Py_DECREF(operator_mod);
+        if (!state->JSON_itemgetter0)
+            return -1;
+    }
+    (void)module;
+    return 0;
+}
+
 #if PY_VERSION_HEX >= 0x030D0000
 /* Multi-phase initialization for Python 3.13+ (PEP 489).
    Required to declare Py_mod_gil for free-threaded Python (PEP 703). */
@@ -3697,72 +3625,12 @@ module_exec(PyObject *m)
     if (state->PyEncoderType == NULL)
         return -1;
 
-    /* Initialize all string constants into per-module state */
-    state->JSON_NaN = PyUnicode_InternFromString("NaN");
-    if (state->JSON_NaN == NULL)
-        return -1;
-    state->JSON_Infinity = PyUnicode_InternFromString("Infinity");
-    if (state->JSON_Infinity == NULL)
-        return -1;
-    state->JSON_NegInfinity = PyUnicode_InternFromString("-Infinity");
-    if (state->JSON_NegInfinity == NULL)
-        return -1;
-    state->JSON_EmptyUnicode = PyUnicode_New(0, 127);
-    if (state->JSON_EmptyUnicode == NULL)
-        return -1;
-    state->JSON_s_null = PyUnicode_InternFromString("null");
-    if (state->JSON_s_null == NULL)
-        return -1;
-    state->JSON_s_true = PyUnicode_InternFromString("true");
-    if (state->JSON_s_true == NULL)
-        return -1;
-    state->JSON_s_false = PyUnicode_InternFromString("false");
-    if (state->JSON_s_false == NULL)
-        return -1;
-    state->JSON_open_dict = PyUnicode_InternFromString("{");
-    if (state->JSON_open_dict == NULL)
-        return -1;
-    state->JSON_close_dict = PyUnicode_InternFromString("}");
-    if (state->JSON_close_dict == NULL)
-        return -1;
-    state->JSON_empty_dict = PyUnicode_InternFromString("{}");
-    if (state->JSON_empty_dict == NULL)
-        return -1;
-    state->JSON_open_array = PyUnicode_InternFromString("[");
-    if (state->JSON_open_array == NULL)
-        return -1;
-    state->JSON_close_array = PyUnicode_InternFromString("]");
-    if (state->JSON_close_array == NULL)
-        return -1;
-    state->JSON_empty_array = PyUnicode_InternFromString("[]");
-    if (state->JSON_empty_array == NULL)
-        return -1;
-    state->JSON_sortargs = PyTuple_New(0);
-    if (state->JSON_sortargs == NULL)
-        return -1;
-
     if (PyModule_AddObjectRef(m, "make_scanner", state->PyScannerType) < 0)
         return -1;
     if (PyModule_AddObjectRef(m, "make_encoder", state->PyEncoderType) < 0)
         return -1;
 
-    state->RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
-    if (state->RawJSONType == NULL)
-        return -1;
-    state->JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
-    if (state->JSONDecodeError == NULL)
-        return -1;
-
-    {
-        PyObject *operator = PyImport_ImportModule("operator");
-        if (!operator)
-            return -1;
-        state->JSON_itemgetter0 = PyObject_CallMethod(operator, "itemgetter", "i", 0);
-        Py_DECREF(operator);
-        if (!state->JSON_itemgetter0)
-            return -1;
-    }
-    return 0;
+    return init_speedups_state(state, m);
 }
 
 static int
@@ -3858,66 +3726,10 @@ import_dependency(char *module_name, char *attr_name)
 }
 
 #if PY_VERSION_HEX < 0x030D0000
-static int
-init_constants(void)
-{
-    JSON_NaN = JSON_InternFromString("NaN");
-    if (JSON_NaN == NULL)
-        return 0;
-    JSON_Infinity = JSON_InternFromString("Infinity");
-    if (JSON_Infinity == NULL)
-        return 0;
-    JSON_NegInfinity = JSON_InternFromString("-Infinity");
-    if (JSON_NegInfinity == NULL)
-        return 0;
-#if PY_MAJOR_VERSION >= 3
-    JSON_EmptyUnicode = PyUnicode_New(0, 127);
-#else /* PY_MAJOR_VERSION >= 3 */
-    JSON_EmptyStr = PyString_FromString("");
-    if (JSON_EmptyStr == NULL)
-        return 0;
-    JSON_EmptyUnicode = PyUnicode_FromUnicode(NULL, 0);
-#endif /* PY_MAJOR_VERSION >= 3 */
-    if (JSON_EmptyUnicode == NULL)
-        return 0;
-
-    JSON_s_null = JSON_InternFromString("null");
-    if (JSON_s_null == NULL)
-        return 0;
-    JSON_s_true = JSON_InternFromString("true");
-    if (JSON_s_true == NULL)
-        return 0;
-    JSON_s_false = JSON_InternFromString("false");
-    if (JSON_s_false == NULL)
-        return 0;
-    JSON_open_dict = JSON_InternFromString("{");
-    if (JSON_open_dict == NULL)
-        return 0;
-    JSON_close_dict = JSON_InternFromString("}");
-    if (JSON_close_dict == NULL)
-        return 0;
-    JSON_empty_dict = JSON_InternFromString("{}");
-    if (JSON_empty_dict == NULL)
-        return 0;
-    JSON_open_array = JSON_InternFromString("[");
-    if (JSON_open_array == NULL)
-        return 0;
-    JSON_close_array = JSON_InternFromString("]");
-    if (JSON_close_array == NULL)
-        return 0;
-    JSON_empty_array = JSON_InternFromString("[]");
-    if (JSON_empty_array == NULL)
-        return 0;
-    JSON_sortargs = PyTuple_New(0);
-    if (JSON_sortargs == NULL)
-        return 0;
-
-    return 1;
-}
-#endif /* PY_VERSION_HEX < 0x030D0000 */
-
-#if PY_VERSION_HEX < 0x030D0000
-/* Single-phase initialization for Python < 3.13 */
+/* Single-phase initialization for Python < 3.13 (including Python 2.7).
+   Populates the single static state instance and captures a borrowed
+   module reference so Scanner/Encoder instances can uniformly store a
+   module_ref pointer. */
 static PyObject *
 moduleinit(void)
 {
@@ -3925,8 +3737,6 @@ moduleinit(void)
     if (PyType_Ready(&PyScannerType) < 0)
         return NULL;
     if (PyType_Ready(&PyEncoderType) < 0)
-        return NULL;
-    if (!init_constants())
         return NULL;
 
 #if PY_MAJOR_VERSION >= 3
@@ -3936,6 +3746,10 @@ moduleinit(void)
 #endif
     if (m == NULL)
         return NULL;
+
+    /* Borrowed reference - sys.modules keeps the module alive. */
+    _speedups_module = m;
+
     Py_INCREF((PyObject*)&PyScannerType);
     if (PyModule_AddObject(m, "make_scanner", (PyObject*)&PyScannerType) < 0) {
         Py_DECREF((PyObject*)&PyScannerType);
@@ -3948,20 +3762,10 @@ moduleinit(void)
         Py_DECREF(m);
         return NULL;
     }
-    RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
-    if (RawJSONType == NULL)
+
+    if (init_speedups_state(&_speedups_static_state, m) < 0) {
+        Py_DECREF(m);
         return NULL;
-    JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
-    if (JSONDecodeError == NULL)
-        return NULL;
-    {
-        PyObject *operator = PyImport_ImportModule("operator");
-        if (!operator)
-            return NULL;
-        JSON_itemgetter0 = PyObject_CallMethod(operator, "itemgetter", "i", 0);
-        Py_DECREF(operator);
-        if (!JSON_itemgetter0)
-            return NULL;
     }
     return m;
 }

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1,6 +1,7 @@
 /* -*- mode: C; c-file-style: "python"; c-basic-offset: 4 -*- */
 #include "Python.h"
 #include "structmember.h"
+#include <limits.h>  /* CHAR_BIT */
 
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_FromSsize_t PyLong_FromSsize_t
@@ -13,6 +14,13 @@
 #define JSON_StringCheck PyUnicode_Check
 #define PY2_UNUSED
 #define PY3_UNUSED UNUSED
+#if PY_VERSION_HEX >= 0x030C0000
+/* PyUnicode_READY was deprecated in 3.10 and is a no-op since 3.12
+ * (PEP 623). Skip calling it on modern Python to avoid the deprecation
+ * warning and the eventual removal. */
+#undef PyUnicode_READY
+#define PyUnicode_READY(obj) 0
+#endif
 #else /* PY_MAJOR_VERSION >= 3 */
 #define PY2_UNUSED UNUSED
 #define PY3_UNUSED
@@ -135,6 +143,11 @@ static PyTypeObject PyEncoderType;
 static inline _speedups_state *
 get_speedups_state(PyObject *module)
 {
+    /* Every call site passes either the module object (from module-level
+     * methods) or Scanner/Encoder->module_ref (set during instance
+     * construction). Both must be non-NULL; catch any regression where an
+     * uninitialized instance leaks into the hot path. */
+    assert(module != NULL);
 #if PY_VERSION_HEX >= 0x030D0000
     void *state = PyModule_GetState(module);
     assert(state != NULL);
@@ -319,10 +332,6 @@ static int
 _call_json_method(PyObject *obj, const char *method_name, PyObject **result);
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
-#if PY_VERSION_HEX < 0x030D0000
-static PyObject *
-moduleinit(void);
-#endif
 static int
 init_speedups_state(_speedups_state *state, PyObject *module);
 static PyObject *
@@ -2741,7 +2750,7 @@ encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (s->iterable_as_array < 0)
         goto bail;
     if (PyInt_Check(int_as_string_bitcount) || PyLong_Check(int_as_string_bitcount)) {
-        static const unsigned long long_long_bitsize = SIZEOF_LONG_LONG * 8;
+        static const unsigned long long_long_bitsize = sizeof(long long) * CHAR_BIT;
         long int_as_string_bitcount_val = PyLong_AsLong(int_as_string_bitcount);
         if (int_as_string_bitcount_val == -1 && PyErr_Occurred())
             goto bail;
@@ -3496,12 +3505,51 @@ static PyMethodDef speedups_methods[] = {
 PyDoc_STRVAR(module_doc,
 "simplejson speedups\n");
 
-/* Shared initializer for per-module state. Used by both module_exec on
-   3.13+ and moduleinit on older versions. Assumes the type fields (on
-   3.13+) have already been populated. */
+/* Clear every state field that init_speedups_state may populate.
+ * Called at the start of init_speedups_state so that re-initialization
+ * (e.g. importlib.reload on pre-3.13 where the static state lives for
+ * the lifetime of the interpreter) releases the previous references
+ * instead of leaking them. Type fields are NOT touched here: on 3.13+
+ * module_exec creates the heap types before calling this function, and
+ * on older versions the type fields hold borrowed pointers to static
+ * PyTypeObjects that must not be cleared. */
+static void
+reset_speedups_state_constants(_speedups_state *state)
+{
+    Py_CLEAR(state->JSON_Infinity);
+    Py_CLEAR(state->JSON_NegInfinity);
+    Py_CLEAR(state->JSON_NaN);
+    Py_CLEAR(state->JSON_EmptyUnicode);
+#if PY_MAJOR_VERSION < 3
+    Py_CLEAR(state->JSON_EmptyStr);
+#endif
+    Py_CLEAR(state->JSON_s_null);
+    Py_CLEAR(state->JSON_s_true);
+    Py_CLEAR(state->JSON_s_false);
+    Py_CLEAR(state->JSON_open_dict);
+    Py_CLEAR(state->JSON_close_dict);
+    Py_CLEAR(state->JSON_empty_dict);
+    Py_CLEAR(state->JSON_open_array);
+    Py_CLEAR(state->JSON_close_array);
+    Py_CLEAR(state->JSON_empty_array);
+    Py_CLEAR(state->JSON_sortargs);
+    Py_CLEAR(state->JSON_itemgetter0);
+    Py_CLEAR(state->RawJSONType);
+    Py_CLEAR(state->JSONDecodeError);
+}
+
+/* Shared initializer for per-module state. Called from module_exec
+   on Python 3 and from init_speedups on Python 2. Assumes the type
+   fields in state have already been populated. */
 static int
 init_speedups_state(_speedups_state *state, PyObject *module)
 {
+    /* Release any prior values. A no-op on the first call (fields are
+     * already NULL from per-module zeroed storage on 3.13+ or from the
+     * static BSS on older versions); on reload this releases the
+     * previous references to avoid a refcount leak. */
+    reset_speedups_state_constants(state);
+
     state->JSON_NaN = JSON_InternFromString("NaN");
     if (state->JSON_NaN == NULL)
         return -1;
@@ -3572,31 +3620,64 @@ init_speedups_state(_speedups_state *state, PyObject *module)
     return 0;
 }
 
-#if PY_VERSION_HEX >= 0x030D0000
-/* Multi-phase initialization for Python 3.13+ (PEP 489).
-   Required to declare Py_mod_gil for free-threaded Python (PEP 703). */
+#if PY_VERSION_HEX >= 0x03050000
+/* Multi-phase initialization (PEP 489) for Python 3.5+. On 3.13+ this
+ * path creates heap types and allocates per-module state so that each
+ * interpreter gets its own copy; on 3.5-3.12 the type fields just point
+ * at the statically-allocated PyTypeObjects and state lives in the
+ * single _speedups_static_state instance. Either way, module_exec does
+ * the work and get_speedups_state() gives uniform access. */
 static int
 module_exec(PyObject *m)
 {
     _speedups_state *state = get_speedups_state(m);
 
-    /* Create heap types from specs, binding them to this module */
+#if PY_VERSION_HEX >= 0x030D0000
+    /* Create heap types from specs, bound to this module */
     state->PyScannerType = PyType_FromModuleAndSpec(m, &PyScannerType_spec, NULL);
     if (state->PyScannerType == NULL)
         return -1;
-
     state->PyEncoderType = PyType_FromModuleAndSpec(m, &PyEncoderType_spec, NULL);
     if (state->PyEncoderType == NULL)
         return -1;
+#else
+    if (PyType_Ready(&PyScannerType) < 0)
+        return -1;
+    if (PyType_Ready(&PyEncoderType) < 0)
+        return -1;
+    /* Static types are eternal, so these are borrowed pointers kept
+     * in the state struct for layout uniformity with the 3.13+ path.
+     * There is nothing to refcount and no GC tracking here. */
+    state->PyScannerType = (PyObject *)&PyScannerType;
+    state->PyEncoderType = (PyObject *)&PyEncoderType;
+    /* Scanner/Encoder instance construction needs a borrowed reference
+     * to the module to store in module_ref; capture it here, before
+     * anything else that might trigger instance creation. */
+    _speedups_module = m;
+#endif
 
+#if PY_VERSION_HEX >= 0x030A0000
     if (PyModule_AddObjectRef(m, "make_scanner", state->PyScannerType) < 0)
         return -1;
     if (PyModule_AddObjectRef(m, "make_encoder", state->PyEncoderType) < 0)
         return -1;
+#else
+    Py_INCREF(state->PyScannerType);
+    if (PyModule_AddObject(m, "make_scanner", state->PyScannerType) < 0) {
+        Py_DECREF(state->PyScannerType);
+        return -1;
+    }
+    Py_INCREF(state->PyEncoderType);
+    if (PyModule_AddObject(m, "make_encoder", state->PyEncoderType) < 0) {
+        Py_DECREF(state->PyEncoderType);
+        return -1;
+    }
+#endif
 
     return init_speedups_state(state, m);
 }
 
+#if PY_VERSION_HEX >= 0x030D0000
 static int
 speedups_traverse(PyObject *m, visitproc visit, void *arg)
 {
@@ -3629,32 +3710,19 @@ speedups_clear(PyObject *m)
     _speedups_state *state = get_speedups_state(m);
     Py_CLEAR(state->PyScannerType);
     Py_CLEAR(state->PyEncoderType);
-    Py_CLEAR(state->JSON_Infinity);
-    Py_CLEAR(state->JSON_NegInfinity);
-    Py_CLEAR(state->JSON_NaN);
-    Py_CLEAR(state->JSON_EmptyUnicode);
-    Py_CLEAR(state->JSON_s_null);
-    Py_CLEAR(state->JSON_s_true);
-    Py_CLEAR(state->JSON_s_false);
-    Py_CLEAR(state->JSON_open_dict);
-    Py_CLEAR(state->JSON_close_dict);
-    Py_CLEAR(state->JSON_empty_dict);
-    Py_CLEAR(state->JSON_open_array);
-    Py_CLEAR(state->JSON_close_array);
-    Py_CLEAR(state->JSON_empty_array);
-    Py_CLEAR(state->JSON_sortargs);
-    Py_CLEAR(state->JSON_itemgetter0);
-    Py_CLEAR(state->RawJSONType);
-    Py_CLEAR(state->JSONDecodeError);
+    reset_speedups_state_constants(state);
     return 0;
 }
+#endif /* PY_VERSION_HEX >= 0x030D0000 */
 
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, module_exec},
+#if PY_VERSION_HEX >= 0x030D0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL}
 };
-#endif /* PY_VERSION_HEX >= 0x030D0000 */
+#endif /* PY_VERSION_HEX >= 0x03050000 */
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
@@ -3663,17 +3731,23 @@ static struct PyModuleDef moduledef = {
     module_doc,         /* m_doc */
 #if PY_VERSION_HEX >= 0x030D0000
     sizeof(_speedups_state), /* m_size */
+#else
+    0,                  /* m_size: no per-module state on <3.13 */
+#endif
     speedups_methods,   /* m_methods */
-    module_slots,       /* m_slots */
+#if PY_VERSION_HEX >= 0x03050000
+    module_slots,       /* m_slots (multi-phase init) */
+#else
+    NULL,               /* m_slots (3.3/3.4: single-phase) */
+#endif
+#if PY_VERSION_HEX >= 0x030D0000
     speedups_traverse,  /* m_traverse */
     speedups_clear,     /* m_clear */
 #else
-    -1,                 /* m_size */
-    speedups_methods,   /* m_methods */
-    NULL,               /* m_slots */
     NULL,               /* m_traverse */
     NULL,               /* m_clear */
 #endif
+    NULL,               /* m_free */
 };
 #endif
 
@@ -3689,74 +3763,55 @@ import_dependency(char *module_name, char *attr_name)
     return rval;
 }
 
-#if PY_VERSION_HEX < 0x030D0000
-/* Single-phase initialization for Python < 3.13 (including Python 2.7).
-   Populates the single static state instance and captures a borrowed
-   module reference so Scanner/Encoder instances can uniformly store a
-   module_ref pointer. */
-static PyObject *
-moduleinit(void)
-{
-    PyObject *m;
-    _speedups_state *state = &_speedups_static_state;
-
-    if (PyType_Ready(&PyScannerType) < 0)
-        return NULL;
-    if (PyType_Ready(&PyEncoderType) < 0)
-        return NULL;
-
-    /* Static types are eternal, so these are borrowed pointers kept
-       in the state struct for layout uniformity with the 3.13+ path.
-       There's no refcount to manage and no GC tracking here. */
-    state->PyScannerType = (PyObject *)&PyScannerType;
-    state->PyEncoderType = (PyObject *)&PyEncoderType;
-
-#if PY_MAJOR_VERSION >= 3
-    m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("_speedups", speedups_methods, module_doc);
-#endif
-    if (m == NULL)
-        return NULL;
-
-    /* Borrowed reference - sys.modules keeps the module alive. */
-    _speedups_module = m;
-
-    Py_INCREF(state->PyScannerType);
-    if (PyModule_AddObject(m, "make_scanner", state->PyScannerType) < 0) {
-        Py_DECREF(state->PyScannerType);
-        Py_DECREF(m);
-        return NULL;
-    }
-    Py_INCREF(state->PyEncoderType);
-    if (PyModule_AddObject(m, "make_encoder", state->PyEncoderType) < 0) {
-        Py_DECREF(state->PyEncoderType);
-        Py_DECREF(m);
-        return NULL;
-    }
-
-    if (init_speedups_state(state, m) < 0) {
-        Py_DECREF(m);
-        return NULL;
-    }
-    return m;
-}
-#endif /* PY_VERSION_HEX < 0x030D0000 */
-
 #if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC
 PyInit__speedups(void)
 {
-#if PY_VERSION_HEX >= 0x030D0000
+#if PY_VERSION_HEX >= 0x03050000
+    /* Multi-phase init: Python runs module_exec via the Py_mod_exec slot */
     return PyModuleDef_Init(&moduledef);
 #else
-    return moduleinit();
+    /* Python 3.3/3.4: fall back to single-phase init */
+    PyObject *m = PyModule_Create(&moduledef);
+    if (m == NULL)
+        return NULL;
+    if (module_exec(m) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    return m;
 #endif
 }
 #else
+/* Python 2.7: single-phase init via Py_InitModule3 */
 void
 init_speedups(void)
 {
-    moduleinit();
+    _speedups_state *state = &_speedups_static_state;
+    PyObject *m;
+
+    if (PyType_Ready(&PyScannerType) < 0)
+        return;
+    if (PyType_Ready(&PyEncoderType) < 0)
+        return;
+    state->PyScannerType = (PyObject *)&PyScannerType;
+    state->PyEncoderType = (PyObject *)&PyEncoderType;
+
+    m = Py_InitModule3("_speedups", speedups_methods, module_doc);
+    if (m == NULL)
+        return;
+    _speedups_module = m;  /* borrowed; sys.modules keeps it alive */
+
+    Py_INCREF(state->PyScannerType);
+    if (PyModule_AddObject(m, "make_scanner", state->PyScannerType) < 0) {
+        Py_DECREF(state->PyScannerType);
+        return;
+    }
+    Py_INCREF(state->PyEncoderType);
+    if (PyModule_AddObject(m, "make_encoder", state->PyEncoderType) < 0) {
+        Py_DECREF(state->PyEncoderType);
+        return;
+    }
+    (void)init_speedups_state(state, m);
 }
 #endif

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2374,21 +2374,40 @@ encoder_listencode_dict(PyEncoderObject *s, JSON_Accu *rval, PyObject *dct, Py_s
         /*
          * Only cache the encoding of string keys. False and True are
          * indistinguishable from 0 and 1 in a dictionary lookup and there
-         * may be other quirks with user defined subclasses.
+         * may be other quirks with user defined subclasses. In the
+         * string-key branch kstr is an INCREF'd alias of key, so storing
+         * under `key` finds the same entry via the `kstr` lookup on the
+         * next iteration. For non-string keys kstr is a freshly created
+         * string object, so a store under `key` would be write-only and
+         * the cache entry would never be reused — skip it entirely.
          */
-        encoded = PyDict_GetItemWithError(s->key_memo, kstr);
-        if (encoded != NULL) {
-            Py_INCREF(encoded);
-            Py_CLEAR(kstr);
-        } else if (PyErr_Occurred()) {
-            goto bail;
-        } else {
-            encoded = encoder_encode_string(s, kstr);
-            Py_CLEAR(kstr);
-            if (encoded == NULL)
-                goto bail;
-            if (PyDict_SetItem(s->key_memo, key, encoded))
-                goto bail;
+        {
+            int is_string_key = PyUnicode_Check(key)
+#if PY_MAJOR_VERSION < 3
+                                || PyString_Check(key)
+#endif
+                                ;
+            if (is_string_key) {
+                encoded = PyDict_GetItemWithError(s->key_memo, kstr);
+                if (encoded != NULL) {
+                    Py_INCREF(encoded);
+                    Py_CLEAR(kstr);
+                } else if (PyErr_Occurred()) {
+                    goto bail;
+                } else {
+                    encoded = encoder_encode_string(s, kstr);
+                    Py_CLEAR(kstr);
+                    if (encoded == NULL)
+                        goto bail;
+                    if (PyDict_SetItem(s->key_memo, key, encoded))
+                        goto bail;
+                }
+            } else {
+                encoded = encoder_encode_string(s, kstr);
+                Py_CLEAR(kstr);
+                if (encoded == NULL)
+                    goto bail;
+            }
         }
         if (JSON_Accu_Accumulate(state, rval, encoded)) {
             goto bail;

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -83,10 +83,33 @@ json_PyOS_string_to_double(const char *s, char **endptr, PyObject *overflow_exce
 
 #define DEFAULT_ENCODING "utf-8"
 
+#if PY_VERSION_HEX >= 0x030D0000
+/* Module state for Python 3.13+ (heap types).
+   Type objects live here for proper GC and lifecycle management.
+   String constants remain as file-scope globals because they are
+   interned / immutable and safe to share across threads. */
+typedef struct {
+    PyObject *PyScannerType;
+    PyObject *PyEncoderType;
+} _speedups_state;
+
+static inline _speedups_state *
+get_speedups_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_speedups_state *)state;
+}
+#endif /* PY_VERSION_HEX >= 0x030D0000 */
+
+#if PY_VERSION_HEX < 0x030D0000
+static PyTypeObject PyScannerType;
+static PyTypeObject PyEncoderType;
 #define PyScanner_Check(op) PyObject_TypeCheck(op, &PyScannerType)
 #define PyScanner_CheckExact(op) (Py_TYPE(op) == &PyScannerType)
 #define PyEncoder_Check(op) PyObject_TypeCheck(op, &PyEncoderType)
 #define PyEncoder_CheckExact(op) (Py_TYPE(op) == &PyEncoderType)
+#endif
 
 #define JSON_ALLOW_NAN 1
 #define JSON_IGNORE_NAN 2
@@ -113,9 +136,6 @@ static PyObject *JSON_close_array = NULL;
 static PyObject *JSON_empty_array = NULL;
 static PyObject *JSON_sortargs = NULL;
 static PyObject *JSON_itemgetter0 = NULL;
-
-static PyTypeObject PyScannerType;
-static PyTypeObject PyEncoderType;
 
 typedef struct {
     PyObject *large_strings;  /* A list of previously accumulated large strings */
@@ -284,8 +304,14 @@ static int
 _call_json_method(PyObject *obj, const char *method_name, PyObject **result);
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
+#if PY_VERSION_HEX < 0x030D0000
 static PyObject *
 moduleinit(void);
+#endif
+static int
+init_constants(void);
+static PyObject *
+import_dependency(char *module_name, char *attr_name);
 
 #define S_CHAR(c) (c >= ' ' && c <= '~' && c != '\\' && c != '"')
 #define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
@@ -1347,17 +1373,28 @@ static void
 scanner_dealloc(PyObject *self)
 {
     /* bpo-31095: UnTrack is needed before calling any callbacks */
+#if PY_VERSION_HEX >= 0x030D0000
+    PyTypeObject *tp = Py_TYPE(self);
+#endif
     PyObject_GC_UnTrack(self);
     scanner_clear(self);
     Py_TYPE(self)->tp_free(self);
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_DECREF(tp);
+#endif
 }
 
 static int
 scanner_traverse(PyObject *self, visitproc visit, void *arg)
 {
     PyScannerObject *s;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyScanner_Check(self));
+#endif
     s = (PyScannerObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_VISIT(Py_TYPE(self));
+#endif
     Py_VISIT(s->encoding);
     Py_VISIT(s->strict_bool);
     Py_VISIT(s->object_hook);
@@ -1373,7 +1410,9 @@ static int
 scanner_clear(PyObject *self)
 {
     PyScannerObject *s;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyScanner_Check(self));
+#endif
     s = (PyScannerObject *)self;
     Py_CLEAR(s->encoding);
     Py_CLEAR(s->strict_bool);
@@ -2372,7 +2411,9 @@ scanner_call(PyObject *self, PyObject *args, PyObject *kwds)
     Py_ssize_t next_idx = -1;
     static char *kwlist[] = {"string", "idx", NULL};
     PyScannerObject *s;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyScanner_Check(self));
+#endif
     s = (PyScannerObject *)self;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&:scan_once", kwlist, &pystr, _convertPyInt_AsSsize_t, &idx))
         return NULL;
@@ -2495,6 +2536,26 @@ bail:
 
 PyDoc_STRVAR(scanner_doc, "JSON scanner object");
 
+#if PY_VERSION_HEX >= 0x030D0000
+/* Heap type slots and spec for Python 3.13+ */
+static PyType_Slot PyScannerType_slots[] = {
+    {Py_tp_doc, (void *)scanner_doc},
+    {Py_tp_dealloc, scanner_dealloc},
+    {Py_tp_call, scanner_call},
+    {Py_tp_traverse, scanner_traverse},
+    {Py_tp_clear, scanner_clear},
+    {Py_tp_members, scanner_members},
+    {Py_tp_new, scanner_new},
+    {0, NULL}
+};
+
+static PyType_Spec PyScannerType_spec = {
+    .name = "simplejson._speedups.Scanner",
+    .basicsize = sizeof(PyScannerObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .slots = PyScannerType_slots,
+};
+#else
 static
 PyTypeObject PyScannerType = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -2537,6 +2598,7 @@ PyTypeObject PyScannerType = {
     scanner_new,          /* tp_new */
     0,/* PyObject_GC_Del, */              /* tp_free */
 };
+#endif
 
 static PyObject *
 encoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
@@ -2718,7 +2780,9 @@ encoder_call(PyObject *self, PyObject *args, PyObject *kwds)
     PyEncoderObject *s;
     JSON_Accu rval;
     int encode_rv;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyEncoder_Check(self));
+#endif
     s = (PyEncoderObject *)self;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&:_iterencode", kwlist,
         &obj, _convertPyInt_AsSsize_t, &indent_level))
@@ -3226,17 +3290,28 @@ static void
 encoder_dealloc(PyObject *self)
 {
     /* bpo-31095: UnTrack is needed before calling any callbacks */
+#if PY_VERSION_HEX >= 0x030D0000
+    PyTypeObject *tp = Py_TYPE(self);
+#endif
     PyObject_GC_UnTrack(self);
     encoder_clear(self);
     Py_TYPE(self)->tp_free(self);
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_DECREF(tp);
+#endif
 }
 
 static int
 encoder_traverse(PyObject *self, visitproc visit, void *arg)
 {
     PyEncoderObject *s;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyEncoder_Check(self));
+#endif
     s = (PyEncoderObject *)self;
+#if PY_VERSION_HEX >= 0x030D0000
+    Py_VISIT(Py_TYPE(self));
+#endif
     Py_VISIT(s->markers);
     Py_VISIT(s->defaultfn);
     Py_VISIT(s->encoder);
@@ -3260,7 +3335,9 @@ encoder_clear(PyObject *self)
 {
     /* Deallocate Encoder */
     PyEncoderObject *s;
+#if PY_VERSION_HEX < 0x030D0000
     assert(PyEncoder_Check(self));
+#endif
     s = (PyEncoderObject *)self;
     Py_CLEAR(s->markers);
     Py_CLEAR(s->defaultfn);
@@ -3282,6 +3359,26 @@ encoder_clear(PyObject *self)
 
 PyDoc_STRVAR(encoder_doc, "_iterencode(obj, _current_indent_level) -> iterable");
 
+#if PY_VERSION_HEX >= 0x030D0000
+/* Heap type slots and spec for Python 3.13+ */
+static PyType_Slot PyEncoderType_slots[] = {
+    {Py_tp_doc, (void *)encoder_doc},
+    {Py_tp_dealloc, encoder_dealloc},
+    {Py_tp_call, encoder_call},
+    {Py_tp_traverse, encoder_traverse},
+    {Py_tp_clear, encoder_clear},
+    {Py_tp_members, encoder_members},
+    {Py_tp_new, encoder_new},
+    {0, NULL}
+};
+
+static PyType_Spec PyEncoderType_spec = {
+    .name = "simplejson._speedups.Encoder",
+    .basicsize = sizeof(PyEncoderObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .slots = PyEncoderType_slots,
+};
+#else
 static
 PyTypeObject PyEncoderType = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -3324,6 +3421,7 @@ PyTypeObject PyEncoderType = {
     encoder_new,          /* tp_new */
     0,                    /* tp_free */
 };
+#endif
 
 static PyMethodDef speedups_methods[] = {
     {"encode_basestring_ascii",
@@ -3340,26 +3438,97 @@ static PyMethodDef speedups_methods[] = {
 PyDoc_STRVAR(module_doc,
 "simplejson speedups\n");
 
+#if PY_VERSION_HEX >= 0x030D0000
+/* Multi-phase initialization for Python 3.13+ (PEP 489).
+   Required to declare Py_mod_gil for free-threaded Python (PEP 703). */
+static int
+module_exec(PyObject *m)
+{
+    _speedups_state *state = get_speedups_state(m);
+
+    /* Create heap types from specs */
+    state->PyScannerType = PyType_FromSpec(&PyScannerType_spec);
+    if (state->PyScannerType == NULL)
+        return -1;
+
+    state->PyEncoderType = PyType_FromSpec(&PyEncoderType_spec);
+    if (state->PyEncoderType == NULL)
+        return -1;
+
+    if (!init_constants())
+        return -1;
+
+    if (PyModule_AddObjectRef(m, "make_scanner", state->PyScannerType) < 0)
+        return -1;
+    if (PyModule_AddObjectRef(m, "make_encoder", state->PyEncoderType) < 0)
+        return -1;
+
+    RawJSONType = import_dependency("simplejson.raw_json", "RawJSON");
+    if (RawJSONType == NULL)
+        return -1;
+    JSONDecodeError = import_dependency("simplejson.errors", "JSONDecodeError");
+    if (JSONDecodeError == NULL)
+        return -1;
+
+    if (JSON_itemgetter0 == NULL) {
+        PyObject *operator = PyImport_ImportModule("operator");
+        if (!operator)
+            return -1;
+        JSON_itemgetter0 = PyObject_CallMethod(operator, "itemgetter", "i", 0);
+        Py_DECREF(operator);
+        if (!JSON_itemgetter0)
+            return -1;
+    }
+    return 0;
+}
+
+static int
+speedups_traverse(PyObject *m, visitproc visit, void *arg)
+{
+    _speedups_state *state = get_speedups_state(m);
+    Py_VISIT(state->PyScannerType);
+    Py_VISIT(state->PyEncoderType);
+    return 0;
+}
+
+static int
+speedups_clear(PyObject *m)
+{
+    _speedups_state *state = get_speedups_state(m);
+    Py_CLEAR(state->PyScannerType);
+    Py_CLEAR(state->PyEncoderType);
+    return 0;
+}
+
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_exec, module_exec},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL}
+};
+#endif /* PY_VERSION_HEX >= 0x030D0000 */
+
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_speedups",        /* m_name */
     module_doc,         /* m_doc */
 #if PY_VERSION_HEX >= 0x030D0000
-    0,                  /* m_size: must be non-negative for PEP 489 (Python >= 3.13) */
-#else
-    -1,                 /* m_size: legacy single-phase module initialization */
-#endif
+    sizeof(_speedups_state), /* m_size */
     speedups_methods,   /* m_methods */
-    NULL,               /* m_slots: removed (no multi-phase init) */
+    module_slots,       /* m_slots */
+    speedups_traverse,  /* m_traverse */
+    speedups_clear,     /* m_clear */
+#else
+    -1,                 /* m_size */
+    speedups_methods,   /* m_methods */
+    NULL,               /* m_slots */
     NULL,               /* m_traverse */
     NULL,               /* m_clear */
-    /* m_free (module deallocator) was removed from PyModuleDef in Python >= 3.14.
-   Only used by modules with per-interpreter state (m_size > 0); not needed here. */
+#endif
 };
 #endif
 
-PyObject *
+static PyObject *
 import_dependency(char *module_name, char *attr_name)
 {
     PyObject *rval;
@@ -3428,6 +3597,8 @@ init_constants(void)
     return 1;
 }
 
+#if PY_VERSION_HEX < 0x030D0000
+/* Single-phase initialization for Python < 3.13 */
 static PyObject *
 moduleinit(void)
 {
@@ -3475,12 +3646,17 @@ moduleinit(void)
     }
     return m;
 }
+#endif /* PY_VERSION_HEX < 0x030D0000 */
 
 #if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC
 PyInit__speedups(void)
 {
+#if PY_VERSION_HEX >= 0x030D0000
+    return PyModuleDef_Init(&moduledef);
+#else
     return moduleinit();
+#endif
 }
 #else
 void

--- a/simplejson/_speedups_scan.h
+++ b/simplejson/_speedups_scan.h
@@ -1,11 +1,23 @@
 /*
  * _speedups_scan.h -- templated JSON scanner function bodies.
  *
- * This file is NOT a traditional header. It contains function definitions
- * and is #included multiple times from _speedups.c with different macro
- * settings to generate both the Py2 bytes (_str) and the universal
- * unicode (_unicode) variants of scan_once, _parse_object, _parse_array,
- * and _match_number without code duplication.
+ * This file is NOT a traditional header and must not be used as one.
+ * It contains function *definitions* and is #included multiple times
+ * from _speedups.c with different macro settings to generate both
+ * the Py2 bytes (_str) and the universal unicode (_unicode) variants
+ * of scan_once, _parse_object, _parse_array, and _match_number
+ * without code duplication. The caller must #define the following
+ * macros before each #include, and must wrap the inclusion with
+ *
+ *     #define JSON_SPEEDUPS_SCAN_INCLUDING 1
+ *     #include "_speedups_scan.h"
+ *     #undef  JSON_SPEEDUPS_SCAN_INCLUDING
+ *
+ * so that accidental inclusion from any other file (or any other
+ * code path in _speedups.c) is caught at compile time. The
+ * JSON_SPEEDUPS_SCAN_INCLUDING gate is the strong form of the
+ * sanity check; missing JSON_SCAN_SUFFIX is a weaker symptom and is
+ * also diagnosed below.
  *
  * Expected macros (must be defined before each #include):
  *
@@ -21,7 +33,24 @@
  *
  * The macros are #undef'd at the bottom of the file so the caller can
  * redefine them for the next #include.
+ *
+ * Example:
+ *
+ *   #define JSON_SCAN_SUFFIX _unicode
+ *   #define JSON_SCAN_DATA_INIT(p) \
+ *       PY2_UNUSED int kind = PyUnicode_KIND(p); \
+ *       void *str = PyUnicode_DATA(p); \
+ *       Py_ssize_t end_idx = PyUnicode_GET_LENGTH(p) - 1
+ *   #define JSON_SCAN_READ(i) PyUnicode_READ(kind, str, (i))
+ *   ...
+ *   #define JSON_SPEEDUPS_SCAN_INCLUDING 1
+ *   #include "_speedups_scan.h"
+ *   #undef  JSON_SPEEDUPS_SCAN_INCLUDING
  */
+
+#ifndef JSON_SPEEDUPS_SCAN_INCLUDING
+#error "_speedups_scan.h must only be included by _speedups.c. See the header comment."
+#endif
 
 #ifndef JSON_SCAN_SUFFIX
 #error "JSON_SCAN_SUFFIX must be defined before including _speedups_scan.h"

--- a/simplejson/_speedups_scan.h
+++ b/simplejson/_speedups_scan.h
@@ -18,8 +18,6 @@
  *                                     substring from start..end
  *   JSON_SCAN_PARSE_FLOAT_FAST(ns)  - Fast-path float parse (or fallback)
  *   JSON_SCAN_PARSE_INT_FAST(ns)    - Fast-path int parse (or fallback)
- *   JSON_SCAN_MAYBE_ENCODING_DECL   - `char *encoding = ...;` for str path,
- *                                     nothing for unicode path
  *
  * The macros are #undef'd at the bottom of the file so the caller can
  * redefine them for the next #include.
@@ -142,7 +140,6 @@ JSON_SCAN_FN(_parse_object)(PyScannerObject *s, PyObject *pystr,
        after the closing curly brace. */
     _speedups_state *state = get_speedups_state(s->module_ref);
     JSON_SCAN_DATA_INIT(pystr);
-    JSON_SCAN_MAYBE_ENCODING_DECL;
     PyObject *rval = NULL;
     PyObject *pairs = NULL;
     PyObject *item;
@@ -511,4 +508,3 @@ JSON_SCAN_FN(scan_once)(PyScannerObject *s, PyObject *pystr,
 #undef JSON_SCAN_NUMSTR_CREATE
 #undef JSON_SCAN_PARSE_FLOAT_FAST
 #undef JSON_SCAN_PARSE_INT_FAST
-#undef JSON_SCAN_MAYBE_ENCODING_DECL

--- a/simplejson/_speedups_scan.h
+++ b/simplejson/_speedups_scan.h
@@ -1,0 +1,514 @@
+/*
+ * _speedups_scan.h -- templated JSON scanner function bodies.
+ *
+ * This file is NOT a traditional header. It contains function definitions
+ * and is #included multiple times from _speedups.c with different macro
+ * settings to generate both the Py2 bytes (_str) and the universal
+ * unicode (_unicode) variants of scan_once, _parse_object, _parse_array,
+ * and _match_number without code duplication.
+ *
+ * Expected macros (must be defined before each #include):
+ *
+ *   JSON_SCAN_SUFFIX                - Either _str or _unicode
+ *   JSON_SCAN_DATA_INIT(pystr)      - Statements to set up `str` (data
+ *                                     pointer) and `end_idx` locals
+ *   JSON_SCAN_READ(idx)             - Read char at idx, returns JSON_UNICHR
+ *   JSON_SCAN_SCANSTRING_CALL(...)  - scanstring_* call with the right args
+ *   JSON_SCAN_NUMSTR_CREATE(s, e)   - Create a PyObject holding the numeric
+ *                                     substring from start..end
+ *   JSON_SCAN_PARSE_FLOAT_FAST(ns)  - Fast-path float parse (or fallback)
+ *   JSON_SCAN_PARSE_INT_FAST(ns)    - Fast-path int parse (or fallback)
+ *   JSON_SCAN_MAYBE_ENCODING_DECL   - `char *encoding = ...;` for str path,
+ *                                     nothing for unicode path
+ *
+ * The macros are #undef'd at the bottom of the file so the caller can
+ * redefine them for the next #include.
+ */
+
+#ifndef JSON_SCAN_SUFFIX
+#error "JSON_SCAN_SUFFIX must be defined before including _speedups_scan.h"
+#endif
+
+#define JSON_SCAN_CONCAT_(a, b) a##b
+#define JSON_SCAN_CONCAT(a, b) JSON_SCAN_CONCAT_(a, b)
+#define JSON_SCAN_FN(base) JSON_SCAN_CONCAT(base, JSON_SCAN_SUFFIX)
+
+static PyObject *
+JSON_SCAN_FN(_match_number)(PyScannerObject *s, PyObject *pystr,
+                            Py_ssize_t start, Py_ssize_t *next_idx_ptr)
+{
+    /* Read a JSON number from pystr.
+       *next_idx_ptr is a return-by-reference index to the first character
+       after the number. Returns a new PyObject representation of that
+       number: PyInt/PyLong or PyFloat, or whatever parse_int/parse_float
+       return if those are set. */
+    _speedups_state *state = get_speedups_state(s->module_ref);
+    JSON_SCAN_DATA_INIT(pystr);
+    Py_ssize_t idx = start;
+    int is_float = 0;
+    JSON_UNICHR c;
+    PyObject *rval;
+    PyObject *numstr;
+
+    /* read a sign if it's there, make sure it's not the end of the string */
+    if (JSON_SCAN_READ(idx) == '-') {
+        if (idx >= end_idx) {
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
+            return NULL;
+        }
+        idx++;
+    }
+
+    /* read as many integer digits as we find as long as it doesn't start with 0 */
+    c = JSON_SCAN_READ(idx);
+    if (c == '0') {
+        /* if it starts with 0 we only expect one integer digit */
+        idx++;
+    }
+    else if (IS_DIGIT(c)) {
+        idx++;
+        while (idx <= end_idx && IS_DIGIT(JSON_SCAN_READ(idx))) {
+            idx++;
+        }
+    }
+    else {
+        /* no integer digits, error */
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, start);
+        return NULL;
+    }
+
+    /* if the next char is '.' followed by a digit then read all float digits */
+    if (idx < end_idx &&
+        JSON_SCAN_READ(idx) == '.' &&
+        IS_DIGIT(JSON_SCAN_READ(idx + 1))) {
+        is_float = 1;
+        idx += 2;
+        while (idx <= end_idx && IS_DIGIT(JSON_SCAN_READ(idx))) idx++;
+    }
+
+    /* if the next char is 'e' or 'E' then maybe read the exponent (or backtrack) */
+    if (idx < end_idx &&
+        (JSON_SCAN_READ(idx) == 'e' || JSON_SCAN_READ(idx) == 'E')) {
+        Py_ssize_t e_start = idx;
+        idx++;
+
+        /* read an exponent sign if present */
+        if (idx < end_idx &&
+            (JSON_SCAN_READ(idx) == '-' || JSON_SCAN_READ(idx) == '+')) idx++;
+
+        /* read all digits */
+        while (idx <= end_idx && IS_DIGIT(JSON_SCAN_READ(idx))) idx++;
+
+        /* if we got a digit, then parse as float. if not, backtrack */
+        if (IS_DIGIT(JSON_SCAN_READ(idx - 1))) {
+            is_float = 1;
+        }
+        else {
+            idx = e_start;
+        }
+    }
+
+    /* copy the section we determined to be a number */
+    numstr = JSON_SCAN_NUMSTR_CREATE(start, idx);
+    if (numstr == NULL)
+        return NULL;
+    if (is_float) {
+        /* parse as a float using a fast path if available,
+           otherwise call user-defined method */
+        if (s->parse_float != (PyObject *)&PyFloat_Type) {
+            rval = PyObject_CallOneArg(s->parse_float, numstr);
+        }
+        else {
+            rval = JSON_SCAN_PARSE_FLOAT_FAST(numstr);
+        }
+    }
+    else {
+        /* parse as an int using a fast path if available,
+           otherwise call user-defined method */
+        rval = JSON_SCAN_PARSE_INT_FAST(numstr);
+    }
+    Py_DECREF(numstr);
+    *next_idx_ptr = idx;
+    return rval;
+}
+
+static PyObject *
+JSON_SCAN_FN(_parse_object)(PyScannerObject *s, PyObject *pystr,
+                            Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+{
+    /* Read a JSON object from pystr.
+       idx is the index of the first character after the opening curly brace.
+       *next_idx_ptr is a return-by-reference index to the first character
+       after the closing curly brace. */
+    _speedups_state *state = get_speedups_state(s->module_ref);
+    JSON_SCAN_DATA_INIT(pystr);
+    JSON_SCAN_MAYBE_ENCODING_DECL;
+    PyObject *rval = NULL;
+    PyObject *pairs = NULL;
+    PyObject *item;
+    PyObject *key = NULL;
+    PyObject *val = NULL;
+    int has_pairs_hook = (s->pairs_hook != Py_None);
+    int did_parse = 0;
+    Py_ssize_t next_idx;
+
+    if (has_pairs_hook) {
+        pairs = PyList_New(0);
+        if (pairs == NULL)
+            return NULL;
+    }
+    else {
+        rval = PyDict_New();
+        if (rval == NULL)
+            return NULL;
+    }
+
+    /* skip whitespace after { */
+    while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+
+    /* only loop if the object is non-empty */
+    if (idx <= end_idx && JSON_SCAN_READ(idx) != '}') {
+        int trailing_delimiter = 0;
+        while (idx <= end_idx) {
+            PyObject *memokey;
+            trailing_delimiter = 0;
+
+            /* read key */
+            if (JSON_SCAN_READ(idx) != '"') {
+                raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
+                goto bail;
+            }
+            key = JSON_SCAN_SCANSTRING_CALL(idx + 1, &next_idx);
+            if (key == NULL)
+                goto bail;
+            memokey = PyDict_GetItemWithError(s->memo, key);
+            if (memokey != NULL) {
+                Py_INCREF(memokey);
+                Py_DECREF(key);
+                key = memokey;
+            }
+            else if (PyErr_Occurred()) {
+                goto bail;
+            }
+            else {
+                if (PyDict_SetItem(s->memo, key, key) < 0)
+                    goto bail;
+            }
+            idx = next_idx;
+
+            /* skip whitespace between key and : delimiter, read :, skip
+               whitespace */
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+            if (idx > end_idx || JSON_SCAN_READ(idx) != ':') {
+                raise_errmsg(state, ERR_OBJECT_PROPERTY_DELIMITER, pystr, idx);
+                goto bail;
+            }
+            idx++;
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+
+            /* read any JSON term */
+            val = JSON_SCAN_FN(scan_once)(s, pystr, idx, &next_idx);
+            if (val == NULL)
+                goto bail;
+
+            if (has_pairs_hook) {
+                item = PyTuple_Pack(2, key, val);
+                if (item == NULL)
+                    goto bail;
+                Py_CLEAR(key);
+                Py_CLEAR(val);
+                if (PyList_Append(pairs, item) == -1) {
+                    Py_DECREF(item);
+                    goto bail;
+                }
+                Py_DECREF(item);
+            }
+            else {
+                if (PyDict_SetItem(rval, key, val) < 0)
+                    goto bail;
+                Py_CLEAR(key);
+                Py_CLEAR(val);
+            }
+            idx = next_idx;
+
+            /* skip whitespace before } or , */
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+
+            /* bail if the object is closed or we didn't get the , delimiter */
+            did_parse = 1;
+            if (idx > end_idx) break;
+            if (JSON_SCAN_READ(idx) == '}') {
+                break;
+            }
+            else if (JSON_SCAN_READ(idx) != ',') {
+                raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
+                goto bail;
+            }
+            idx++;
+
+            /* skip whitespace after , delimiter */
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+            trailing_delimiter = 1;
+        }
+        if (trailing_delimiter) {
+            raise_errmsg(state, ERR_OBJECT_PROPERTY, pystr, idx);
+            goto bail;
+        }
+    }
+
+    /* verify that idx < end_idx, str[idx] should be '}' */
+    if (idx > end_idx || JSON_SCAN_READ(idx) != '}') {
+        if (did_parse) {
+            raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
+        } else {
+            raise_errmsg(state, ERR_OBJECT_PROPERTY_FIRST, pystr, idx);
+        }
+        goto bail;
+    }
+
+    /* if pairs_hook is not None: rval = object_pairs_hook(pairs) */
+    if (s->pairs_hook != Py_None) {
+        val = PyObject_CallOneArg(s->pairs_hook, pairs);
+        if (val == NULL)
+            goto bail;
+        Py_DECREF(pairs);
+        *next_idx_ptr = idx + 1;
+        return val;
+    }
+
+    /* if object_hook is not None: rval = object_hook(rval) */
+    if (s->object_hook != Py_None) {
+        val = PyObject_CallOneArg(s->object_hook, rval);
+        if (val == NULL)
+            goto bail;
+        Py_DECREF(rval);
+        rval = val;
+        val = NULL;
+    }
+    *next_idx_ptr = idx + 1;
+    return rval;
+bail:
+    Py_XDECREF(rval);
+    Py_XDECREF(key);
+    Py_XDECREF(val);
+    Py_XDECREF(pairs);
+    return NULL;
+}
+
+static PyObject *
+JSON_SCAN_FN(_parse_array)(PyScannerObject *s, PyObject *pystr,
+                           Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+{
+    /* Read a JSON array from pystr.
+       idx is the index of the first character after the opening brace.
+       *next_idx_ptr is a return-by-reference index to the first character
+       after the closing brace. */
+    _speedups_state *state = get_speedups_state(s->module_ref);
+    JSON_SCAN_DATA_INIT(pystr);
+    PyObject *val = NULL;
+    PyObject *rval = PyList_New(0);
+    Py_ssize_t next_idx;
+    if (rval == NULL)
+        return NULL;
+
+    /* skip whitespace after [ */
+    while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+
+    /* only loop if the array is non-empty */
+    if (idx <= end_idx && JSON_SCAN_READ(idx) != ']') {
+        int trailing_delimiter = 0;
+        while (idx <= end_idx) {
+            trailing_delimiter = 0;
+            /* read any JSON term and de-tuplefy the (rval, idx) */
+            val = JSON_SCAN_FN(scan_once)(s, pystr, idx, &next_idx);
+            if (val == NULL) {
+                goto bail;
+            }
+
+            if (PyList_Append(rval, val) == -1)
+                goto bail;
+
+            Py_CLEAR(val);
+            idx = next_idx;
+
+            /* skip whitespace between term and , */
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+
+            /* bail if the array is closed or we didn't get the , delimiter */
+            if (idx > end_idx) break;
+            if (JSON_SCAN_READ(idx) == ']') {
+                break;
+            }
+            else if (JSON_SCAN_READ(idx) != ',') {
+                raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
+                goto bail;
+            }
+            idx++;
+
+            /* skip whitespace after , */
+            while (idx <= end_idx && IS_WHITESPACE(JSON_SCAN_READ(idx))) idx++;
+            trailing_delimiter = 1;
+        }
+        if (trailing_delimiter) {
+            raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
+            goto bail;
+        }
+    }
+
+    /* verify that idx < end_idx, str[idx] should be ']' */
+    if (idx > end_idx || JSON_SCAN_READ(idx) != ']') {
+        if (PyList_GET_SIZE(rval)) {
+            raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
+        } else {
+            raise_errmsg(state, ERR_ARRAY_VALUE_FIRST, pystr, idx);
+        }
+        goto bail;
+    }
+    *next_idx_ptr = idx + 1;
+    return rval;
+bail:
+    Py_XDECREF(val);
+    Py_DECREF(rval);
+    return NULL;
+}
+
+static PyObject *
+JSON_SCAN_FN(scan_once)(PyScannerObject *s, PyObject *pystr,
+                        Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+{
+    /* Read one JSON term (of any kind) from pystr.
+       idx is the index of the first character of the term.
+       *next_idx_ptr is a return-by-reference index to the first character
+       after the term. */
+    _speedups_state *state = get_speedups_state(s->module_ref);
+    JSON_SCAN_DATA_INIT(pystr);
+    Py_ssize_t length = end_idx + 1;
+    PyObject *rval = NULL;
+    int fallthrough = 0;
+    if (idx < 0 || idx >= length) {
+        raise_errmsg(state, ERR_EXPECTING_VALUE, pystr, idx);
+        return NULL;
+    }
+    switch (JSON_SCAN_READ(idx)) {
+        case '"':
+            /* string */
+            rval = JSON_SCAN_SCANSTRING_CALL(idx + 1, next_idx_ptr);
+            break;
+        case '{':
+            /* object */
+            if (Py_EnterRecursiveCall(" while decoding a JSON object "
+                                      "from a string"))
+                return NULL;
+            rval = JSON_SCAN_FN(_parse_object)(s, pystr, idx + 1, next_idx_ptr);
+            Py_LeaveRecursiveCall();
+            break;
+        case '[':
+            /* array */
+            if (Py_EnterRecursiveCall(" while decoding a JSON array "
+                                      "from a string"))
+                return NULL;
+            rval = JSON_SCAN_FN(_parse_array)(s, pystr, idx + 1, next_idx_ptr);
+            Py_LeaveRecursiveCall();
+            break;
+        case 'n':
+            /* null */
+            if ((idx + 3 < length)
+                && JSON_SCAN_READ(idx + 1) == 'u'
+                && JSON_SCAN_READ(idx + 2) == 'l'
+                && JSON_SCAN_READ(idx + 3) == 'l') {
+                Py_INCREF(Py_None);
+                *next_idx_ptr = idx + 4;
+                rval = Py_None;
+            }
+            else
+                fallthrough = 1;
+            break;
+        case 't':
+            /* true */
+            if ((idx + 3 < length)
+                && JSON_SCAN_READ(idx + 1) == 'r'
+                && JSON_SCAN_READ(idx + 2) == 'u'
+                && JSON_SCAN_READ(idx + 3) == 'e') {
+                Py_INCREF(Py_True);
+                *next_idx_ptr = idx + 4;
+                rval = Py_True;
+            }
+            else
+                fallthrough = 1;
+            break;
+        case 'f':
+            /* false */
+            if ((idx + 4 < length)
+                && JSON_SCAN_READ(idx + 1) == 'a'
+                && JSON_SCAN_READ(idx + 2) == 'l'
+                && JSON_SCAN_READ(idx + 3) == 's'
+                && JSON_SCAN_READ(idx + 4) == 'e') {
+                Py_INCREF(Py_False);
+                *next_idx_ptr = idx + 5;
+                rval = Py_False;
+            }
+            else
+                fallthrough = 1;
+            break;
+        case 'N':
+            /* NaN */
+            if ((idx + 2 < length)
+                && JSON_SCAN_READ(idx + 1) == 'a'
+                && JSON_SCAN_READ(idx + 2) == 'N') {
+                rval = _parse_constant(s, pystr, state->JSON_NaN, idx, next_idx_ptr);
+            }
+            else
+                fallthrough = 1;
+            break;
+        case 'I':
+            /* Infinity */
+            if ((idx + 7 < length)
+                && JSON_SCAN_READ(idx + 1) == 'n'
+                && JSON_SCAN_READ(idx + 2) == 'f'
+                && JSON_SCAN_READ(idx + 3) == 'i'
+                && JSON_SCAN_READ(idx + 4) == 'n'
+                && JSON_SCAN_READ(idx + 5) == 'i'
+                && JSON_SCAN_READ(idx + 6) == 't'
+                && JSON_SCAN_READ(idx + 7) == 'y') {
+                rval = _parse_constant(s, pystr, state->JSON_Infinity, idx, next_idx_ptr);
+            }
+            else
+                fallthrough = 1;
+            break;
+        case '-':
+            /* -Infinity */
+            if ((idx + 8 < length)
+                && JSON_SCAN_READ(idx + 1) == 'I'
+                && JSON_SCAN_READ(idx + 2) == 'n'
+                && JSON_SCAN_READ(idx + 3) == 'f'
+                && JSON_SCAN_READ(idx + 4) == 'i'
+                && JSON_SCAN_READ(idx + 5) == 'n'
+                && JSON_SCAN_READ(idx + 6) == 'i'
+                && JSON_SCAN_READ(idx + 7) == 't'
+                && JSON_SCAN_READ(idx + 8) == 'y') {
+                rval = _parse_constant(s, pystr, state->JSON_NegInfinity, idx, next_idx_ptr);
+            }
+            else
+                fallthrough = 1;
+            break;
+        default:
+            fallthrough = 1;
+    }
+    /* Didn't find a string, object, array, or named constant.
+       Look for a number. */
+    if (fallthrough)
+        rval = JSON_SCAN_FN(_match_number)(s, pystr, idx, next_idx_ptr);
+    return rval;
+}
+
+#undef JSON_SCAN_FN
+#undef JSON_SCAN_CONCAT
+#undef JSON_SCAN_CONCAT_
+#undef JSON_SCAN_SUFFIX
+#undef JSON_SCAN_DATA_INIT
+#undef JSON_SCAN_READ
+#undef JSON_SCAN_SCANSTRING_CALL
+#undef JSON_SCAN_NUMSTR_CREATE
+#undef JSON_SCAN_PARSE_FLOAT_FAST
+#undef JSON_SCAN_PARSE_INT_FAST
+#undef JSON_SCAN_MAYBE_ENCODING_DECL

--- a/simplejson/compat.py
+++ b/simplejson/compat.py
@@ -2,17 +2,6 @@
 """
 import sys
 
-def is_gil_enabled():
-    """Return True if the CPython runtime currently has the GIL enabled."""
-    getter = getattr(sys, "_is_gil_enabled", None)
-    if getter is None:
-        return True
-    try:
-        return bool(getter())
-    except RuntimeError:
-        # Some runtimes may raise if called before fully initialized.
-        return True
-
 if sys.version_info[0] < 3:
     PY3 = False
     def b(s):

--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -4,13 +4,11 @@ from __future__ import absolute_import
 import re
 import sys
 import struct
-from .compat import PY3, unichr, is_gil_enabled
+from .compat import PY3, unichr
 from .scanner import make_scanner, JSONDecodeError
 
 
 def _import_c_scanstring():
-    if not is_gil_enabled():
-        return None
     try:
         from ._speedups import scanstring
         return scanstring

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -5,11 +5,9 @@ import re
 from operator import itemgetter
 # Do not import Decimal directly to avoid reload issues
 import decimal
-from .compat import binary_type, text_type, string_types, integer_types, PY3, is_gil_enabled
+from .compat import binary_type, text_type, string_types, integer_types, PY3
 
 def _import_speedups():
-    if not is_gil_enabled():
-        return None, None
     try:
         from . import _speedups
         return _speedups.encode_basestring_ascii, _speedups.make_encoder

--- a/simplejson/scanner.py
+++ b/simplejson/scanner.py
@@ -2,11 +2,8 @@
 """
 import re
 from .errors import JSONDecodeError
-from .compat import is_gil_enabled
 
 def _import_c_make_scanner():
-    if not is_gil_enabled():
-        return None
     try:
         from ._speedups import make_scanner
         return make_scanner

--- a/simplejson/tests/_helpers.py
+++ b/simplejson/tests/_helpers.py
@@ -1,0 +1,24 @@
+"""Shared helpers for the simplejson C extension test files."""
+from __future__ import with_statement
+
+import sys
+import unittest
+
+from simplejson import encoder
+
+
+def has_speedups():
+    return encoder.c_make_encoder is not None
+
+
+def skip_if_speedups_missing(func):
+    def wrapper(*args, **kwargs):
+        if not has_speedups():
+            if hasattr(unittest, 'SkipTest'):
+                raise unittest.SkipTest("C Extension not available")
+            else:
+                sys.stdout.write("C Extension not available")
+                return
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/simplejson/tests/test_bitsize_int_as_string.py
+++ b/simplejson/tests/test_bitsize_int_as_string.py
@@ -91,3 +91,30 @@ class TestBitSizeIntAsString(TestCase):
             self.assertEqual(
                 expect,
                 json.loads(json.dumps(val, int_as_string_bitcount=31)))
+
+    def test_boundary_at_max_bitcount(self):
+        """Regression test for -Wshift-negative-value UB in encoder_new.
+
+        The C implementation computes ``-(2 ** n)`` as the minimum
+        stringifiable value; the naive ``-1LL << n`` expression is
+        undefined behavior and overflows into LLONG_MIN incorrectly for
+        n == 63. Exercise each bitcount from 1 to 63 with the exact
+        boundary values to catch any regression in that computation.
+        """
+        max_n = 63
+        for n in (1, 8, 31, 32, 62, max_n):
+            boundary = 1 << n  # i.e. 2**n
+            just_inside_pos = boundary - 1
+            just_inside_neg = -boundary + 1
+            # Values strictly inside [-2**n + 1, 2**n - 1] stay as ints
+            for v in (0, 1, -1, just_inside_pos, just_inside_neg):
+                self.assertEqual(
+                    v,
+                    json.loads(json.dumps(v, int_as_string_bitcount=n)),
+                    "n=%d v=%d should stay an int" % (n, v))
+            # Values at +/- 2**n get stringified (they're at the boundary)
+            for v in (boundary, -boundary):
+                self.assertEqual(
+                    str(v),
+                    json.loads(json.dumps(v, int_as_string_bitcount=n)),
+                    "n=%d v=%d should be stringified" % (n, v))

--- a/simplejson/tests/test_free_threading.py
+++ b/simplejson/tests/test_free_threading.py
@@ -8,24 +8,10 @@ disabled. The test_free_threading CI job runs these with
 from __future__ import with_statement
 
 import threading
-import unittest
 from unittest import TestCase
 
 import simplejson
-from simplejson import encoder
-
-
-def has_speedups():
-    return encoder.c_make_encoder is not None
-
-
-def skip_if_speedups_missing(func):
-    def wrapper(*args, **kwargs):
-        if not has_speedups():
-            raise unittest.SkipTest("C Extension not available")
-        return func(*args, **kwargs)
-
-    return wrapper
+from simplejson.tests._helpers import skip_if_speedups_missing
 
 
 class TestFreeThreading(TestCase):

--- a/simplejson/tests/test_free_threading.py
+++ b/simplejson/tests/test_free_threading.py
@@ -1,0 +1,113 @@
+"""Tests that exercise the C extension from multiple threads.
+
+These tests pass on any Python build but their real purpose is to
+catch data races on free-threaded builds (PEP 703) where the GIL is
+disabled. The test_free_threading CI job runs these with
+``PYTHON_GIL=0`` on a free-threaded interpreter.
+"""
+from __future__ import with_statement
+
+import threading
+import unittest
+from unittest import TestCase
+
+import simplejson
+from simplejson import encoder
+
+
+def has_speedups():
+    return encoder.c_make_encoder is not None
+
+
+def skip_if_speedups_missing(func):
+    def wrapper(*args, **kwargs):
+        if not has_speedups():
+            raise unittest.SkipTest("C Extension not available")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class TestFreeThreading(TestCase):
+    """Exercise the C extension from multiple threads simultaneously."""
+
+    N_THREADS = 8
+    N_ITER = 500
+
+    def _run_threads(self, worker):
+        errors = []
+
+        def wrapped():
+            try:
+                worker()
+            except BaseException as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=wrapped)
+                   for _ in range(self.N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        if errors:
+            raise errors[0]
+
+    @skip_if_speedups_missing
+    def test_concurrent_encode(self):
+        data = {
+            "numbers": list(range(64)),
+            "nested": {"key": "value", "list": [1, 2.5, None, True, False]},
+            "string": "hello \u00e9 world",
+        }
+        expected = simplejson.dumps(data, sort_keys=True)
+
+        def worker():
+            for _ in range(self.N_ITER):
+                self.assertEqual(
+                    simplejson.dumps(data, sort_keys=True), expected)
+
+        self._run_threads(worker)
+
+    @skip_if_speedups_missing
+    def test_concurrent_decode(self):
+        raw = (
+            '{"numbers": [1, 2, 3, 4, 5], '
+            '"nested": {"a": "b", "c": [true, false, null]}, '
+            '"string": "hello"}'
+        )
+        expected = simplejson.loads(raw)
+
+        def worker():
+            for _ in range(self.N_ITER):
+                self.assertEqual(simplejson.loads(raw), expected)
+
+        self._run_threads(worker)
+
+    @skip_if_speedups_missing
+    def test_concurrent_encode_decode(self):
+        """Mix encode and decode on the same data across threads."""
+        data = {"items": list(range(32)), "flag": True, "name": "mix"}
+        raw = simplejson.dumps(data, sort_keys=True)
+
+        def worker():
+            for _ in range(self.N_ITER):
+                s = simplejson.dumps(data, sort_keys=True)
+                self.assertEqual(s, raw)
+                self.assertEqual(simplejson.loads(s), data)
+
+        self._run_threads(worker)
+
+    @skip_if_speedups_missing
+    def test_shared_encoder_instance(self):
+        """A single encoder/decoder instance used by many threads."""
+        enc = simplejson.JSONEncoder(sort_keys=True)
+        dec = simplejson.JSONDecoder()
+        data = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}}
+        raw = enc.encode(data)
+
+        def worker():
+            for _ in range(self.N_ITER):
+                self.assertEqual(enc.encode(data), raw)
+                self.assertEqual(dec.decode(raw), data)
+
+        self._run_threads(worker)

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -248,3 +248,4 @@ class TestRefcountLeaks(TestCase):
 
         self._assert_no_leak(try_bad_scanner)
         self._assert_no_leak(try_bad_encoder)
+

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -156,3 +156,74 @@ class TestHeapTypes(TestCase):
         """Verify Encoder heap type instances encode correctly."""
         result = simplejson.dumps({"a": 1}, sort_keys=True)
         self.assertEqual(result, '{"a": 1}')
+
+
+@unittest.skipUnless(hasattr(sys, "gettotalrefcount"),
+                     "debug build required (sys.gettotalrefcount)")
+class TestRefcountLeaks(TestCase):
+    """Catch refcount leaks in the C extension.
+
+    These tests only run on debug builds of CPython, which expose
+    sys.gettotalrefcount(). On release builds they skip silently.
+    """
+
+    ITER = 2000
+
+    def _assert_no_leak(self, func):
+        import gc
+        # Warm up to stabilize caches (interned strings, module state, etc.)
+        for _ in range(50):
+            func()
+        gc.collect()
+        before = sys.gettotalrefcount()
+        for _ in range(self.ITER):
+            func()
+        gc.collect()
+        after = sys.gettotalrefcount()
+        delta = after - before
+        # Allow a small slack for debug build internals, but any real
+        # leak would grow linearly with ITER.
+        self.assertLess(abs(delta), 50,
+                        "refcount delta=%d over %d iterations"
+                        % (delta, self.ITER))
+
+    @skip_if_speedups_missing
+    def test_dumps_no_leak(self):
+        data = {"a": [1, 2, 3], "b": "hello", "c": None, "d": True}
+        self._assert_no_leak(lambda: simplejson.dumps(data))
+
+    @skip_if_speedups_missing
+    def test_loads_no_leak(self):
+        raw = '{"a": [1, 2, 3], "b": "hello", "c": null, "d": true}'
+        self._assert_no_leak(lambda: simplejson.loads(raw))
+
+    @skip_if_speedups_missing
+    def test_scanner_construction_no_leak(self):
+        self._assert_no_leak(lambda: simplejson.JSONDecoder())
+
+    @skip_if_speedups_missing
+    def test_encoder_construction_no_leak(self):
+        self._assert_no_leak(lambda: simplejson.JSONEncoder())
+
+    @skip_if_speedups_missing
+    def test_failed_construction_no_leak(self):
+        """Error path in scanner_new/encoder_new must release module_ref."""
+        class BadBool:
+            def __bool__(self):
+                raise ZeroDivisionError()
+            __nonzero__ = __bool__
+
+        def try_bad_scanner():
+            try:
+                decoder.JSONDecoder(strict=BadBool()).decode('{}')
+            except ZeroDivisionError:
+                pass
+
+        def try_bad_encoder():
+            try:
+                encoder.JSONEncoder(skipkeys=BadBool()).encode({})
+            except ZeroDivisionError:
+                pass
+
+        self._assert_no_leak(try_bad_scanner)
+        self._assert_no_leak(try_bad_encoder)

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -112,3 +112,47 @@ class TestEncode(TestCase):
         def test_bad_encoding(self):
             with self.assertRaises(UnicodeEncodeError):
                 encoder.JSONEncoder(encoding='\udcff').encode({b('key'): 123})
+
+
+@unittest.skipIf(sys.version_info < (3, 13),
+                 "heap types require Python 3.13+")
+class TestHeapTypes(TestCase):
+    """Verify that Scanner and Encoder are heap types on Python 3.13+."""
+
+    @skip_if_speedups_missing
+    def test_scanner_is_heap_type(self):
+        from simplejson._speedups import make_scanner
+        # Py_TPFLAGS_HEAPTYPE = 1 << 9
+        self.assertTrue(make_scanner.__flags__ & (1 << 9),
+                        "Scanner should be a heap type on 3.13+")
+
+    @skip_if_speedups_missing
+    def test_encoder_is_heap_type(self):
+        from simplejson._speedups import make_encoder
+        self.assertTrue(make_encoder.__flags__ & (1 << 9),
+                        "Encoder should be a heap type on 3.13+")
+
+    @skip_if_speedups_missing
+    def test_scanner_type_is_gc_tracked(self):
+        """Heap types must be GC-tracked so they can be collected."""
+        import gc
+        from simplejson._speedups import make_scanner
+        self.assertTrue(gc.is_tracked(make_scanner))
+
+    @skip_if_speedups_missing
+    def test_encoder_type_is_gc_tracked(self):
+        import gc
+        from simplejson._speedups import make_encoder
+        self.assertTrue(gc.is_tracked(make_encoder))
+
+    @skip_if_speedups_missing
+    def test_scanner_instances_work(self):
+        """Verify Scanner heap type instances decode correctly."""
+        result = simplejson.loads('{"a": 1}')
+        self.assertEqual(result, {"a": 1})
+
+    @skip_if_speedups_missing
+    def test_encoder_instances_work(self):
+        """Verify Encoder heap type instances encode correctly."""
+        result = simplejson.dumps({"a": 1}, sort_keys=True)
+        self.assertEqual(result, '{"a": 1}')

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -168,24 +168,45 @@ class TestRefcountLeaks(TestCase):
     """
 
     ITER = 2000
+    WARMUP = 200
 
     def _assert_no_leak(self, func):
+        """Run `func` in two measurement phases and verify the second
+        phase's refcount delta stays near zero.
+
+        A real per-call leak (1 ref per call) grows linearly with the
+        iteration count, so both phase1 and phase2 would be ~ITER. But
+        front-loaded noise -- specializer inline caches, dict resize,
+        gc generation bumps, etc. -- shows up entirely in phase1 and
+        leaves phase2 near zero. Asserting on phase2 only is thus both
+        more sensitive (catches smaller linear leaks) and more robust
+        (no false positives from CPython internals).
+        """
         import gc
-        # Warm up to stabilize caches (interned strings, module state, etc.)
-        for _ in range(50):
+        # Stabilize caches, specializer, intern pools, etc.
+        for _ in range(self.WARMUP):
             func()
         gc.collect()
-        before = sys.gettotalrefcount()
+
+        start = sys.gettotalrefcount()
         for _ in range(self.ITER):
             func()
         gc.collect()
-        after = sys.gettotalrefcount()
-        delta = after - before
-        # Allow a small slack for debug build internals, but any real
-        # leak would grow linearly with ITER.
-        self.assertLess(abs(delta), 50,
-                        "refcount delta=%d over %d iterations"
-                        % (delta, self.ITER))
+        mid = sys.gettotalrefcount()
+        for _ in range(self.ITER):
+            func()
+        gc.collect()
+        end = sys.gettotalrefcount()
+
+        phase1 = mid - start
+        phase2 = end - mid
+        msg = ("phase1=%d, phase2=%d, iterations=%d. A real per-call "
+               "leak would make phase2 grow linearly with iterations."
+               % (phase1, phase2, self.ITER))
+        # phase2 observed as 1-24 on CPython 3.14 debug when clean;
+        # 100 is a generous ceiling that still fails on any leak
+        # producing more than ~0.05 refs/call.
+        self.assertLess(abs(phase2), 100, msg)
 
     @skip_if_speedups_missing
     def test_dumps_no_leak(self):

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -233,3 +233,63 @@ class TestRefcountLeaks(TestCase):
         self._assert_no_leak(try_bad_scanner)
         self._assert_no_leak(try_bad_encoder)
 
+    @skip_if_speedups_missing
+    def test_circular_reference_no_leak(self):
+        """ValueError mid-encode must not leak the partial accumulator,
+        markers dict entry, or the ident PyLong."""
+        def circular():
+            d = {}
+            d["self"] = d
+            try:
+                simplejson.dumps(d)
+            except ValueError:
+                pass
+        self._assert_no_leak(circular)
+
+    @skip_if_speedups_missing
+    def test_asdict_returning_non_dict_no_leak(self):
+        """encoder_steal_encode's TypeError path on _asdict() returning
+        a non-dict must release the stolen newobj reference."""
+        class BadNT:
+            def _asdict(self):
+                return "not a dict"
+
+        def bad_asdict():
+            try:
+                simplejson.dumps(BadNT(), namedtuple_as_object=True)
+            except TypeError:
+                pass
+        self._assert_no_leak(bad_asdict)
+
+    @skip_if_speedups_missing
+    def test_for_json_raising_no_leak(self):
+        """for_json() raising inside its body must not leak the method
+        binding or partial accumulator state."""
+        class Explodes:
+            def for_json(self):
+                raise RuntimeError("boom")
+
+        def explode():
+            try:
+                simplejson.dumps(Explodes(), for_json=True)
+            except RuntimeError:
+                pass
+        self._assert_no_leak(explode)
+
+    @skip_if_speedups_missing
+    def test_non_string_dict_keys_no_leak(self):
+        """Dict keys that aren't already strings go through
+        encoder_stringify_key and the non-cached branch of the key_memo
+        logic. Both paths must release the transient stringified key."""
+        data = {1: "a", 2: "b", 3: "c", True: "x", False: "y"}
+        self._assert_no_leak(lambda: simplejson.dumps(data, sort_keys=True))
+
+    @skip_if_speedups_missing
+    def test_bigint_as_string_no_leak(self):
+        """maybe_quote_bigint's comparison path must release `encoded`
+        on the RichCompareBool error branch and on the quoted-return
+        path that replaces the unquoted string."""
+        big = 1 << 40
+        self._assert_no_leak(
+            lambda: simplejson.dumps(big, int_as_string_bitcount=31))
+

--- a/simplejson/tests/test_speedups.py
+++ b/simplejson/tests/test_speedups.py
@@ -7,23 +7,7 @@ from unittest import TestCase
 import simplejson
 from simplejson import encoder, decoder, scanner
 from simplejson.compat import PY3, long_type, b
-
-
-def has_speedups():
-    return encoder.c_make_encoder is not None
-
-
-def skip_if_speedups_missing(func):
-    def wrapper(*args, **kwargs):
-        if not has_speedups():
-            if hasattr(unittest, 'SkipTest'):
-                raise unittest.SkipTest("C Extension not available")
-            else:
-                sys.stdout.write("C Extension not available")
-                return
-        return func(*args, **kwargs)
-
-    return wrapper
+from simplejson.tests._helpers import has_speedups, skip_if_speedups_missing
 
 
 class BadBool:

--- a/simplejson/tests/test_subinterpreters.py
+++ b/simplejson/tests/test_subinterpreters.py
@@ -1,0 +1,140 @@
+"""Tests that verify the C extension works in subinterpreters.
+
+Subinterpreters became usable for third-party C extensions in
+Python 3.12 (PEP 684). On 3.13+ the extension uses per-module state
+and heap types so that each interpreter gets its own copy.
+"""
+from __future__ import with_statement
+
+import sys
+import unittest
+from unittest import TestCase
+
+from simplejson import encoder
+
+
+def has_speedups():
+    return encoder.c_make_encoder is not None
+
+
+def skip_if_speedups_missing(func):
+    def wrapper(*args, **kwargs):
+        if not has_speedups():
+            raise unittest.SkipTest("C Extension not available")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@unittest.skipIf(sys.version_info < (3, 12),
+                 "subinterpreters require Python 3.12+")
+class TestSubinterpreters(TestCase):
+    """Test that the C extension can be loaded in subinterpreters."""
+
+    def _run_in_subinterp(self, code):
+        """Helper to run code in a fresh subinterpreter."""
+        try:
+            import _interpreters
+        except ImportError:
+            raise unittest.SkipTest("_interpreters not available")
+        interp = _interpreters.create()
+        try:
+            _interpreters.run_string(interp, code)
+        finally:
+            _interpreters.destroy(interp)
+
+    @skip_if_speedups_missing
+    def test_import_in_subinterpreter(self):
+        """Verify _speedups can be imported in a subinterpreter."""
+        self._run_in_subinterp(
+            "import simplejson; simplejson.dumps({'a': 1})")
+
+    @skip_if_speedups_missing
+    def test_encode_in_subinterpreter(self):
+        """Verify encoding works correctly in a subinterpreter."""
+        self._run_in_subinterp("""
+import simplejson
+assert simplejson.dumps(None) == 'null'
+assert simplejson.dumps(True) == 'true'
+assert simplejson.dumps(False) == 'false'
+assert simplejson.dumps(42) == '42'
+assert simplejson.dumps(3.14) == '3.14'
+assert simplejson.dumps("hello") == '"hello"'
+assert simplejson.dumps([1, 2, 3]) == '[1, 2, 3]'
+assert simplejson.dumps({"a": 1}, sort_keys=True) == '{"a": 1}'
+""")
+
+    @skip_if_speedups_missing
+    def test_decode_in_subinterpreter(self):
+        """Verify decoding works correctly in a subinterpreter."""
+        self._run_in_subinterp("""
+import simplejson
+assert simplejson.loads('null') is None
+assert simplejson.loads('true') is True
+assert simplejson.loads('42') == 42
+assert simplejson.loads('"hello"') == 'hello'
+assert simplejson.loads('[1, 2, 3]') == [1, 2, 3]
+assert simplejson.loads('{"a": 1}') == {"a": 1}
+""")
+
+    @skip_if_speedups_missing
+    def test_multiple_subinterpreters(self):
+        """Verify multiple subinterpreters can use simplejson concurrently."""
+        try:
+            import _interpreters
+        except ImportError:
+            raise unittest.SkipTest("_interpreters not available")
+        interps = [_interpreters.create() for _ in range(3)]
+        try:
+            for i, interp in enumerate(interps):
+                _interpreters.run_string(interp, """
+import simplejson
+result = simplejson.dumps({"interp": %d})
+assert '"interp": %d' in result
+""" % (i, i))
+        finally:
+            for interp in interps:
+                _interpreters.destroy(interp)
+
+    @skip_if_speedups_missing
+    def test_subinterpreter_state_independent(self):
+        """Verify destroying one subinterpreter doesn't affect another."""
+        try:
+            import _interpreters
+        except ImportError:
+            raise unittest.SkipTest("_interpreters not available")
+        interp1 = _interpreters.create()
+        interp2 = _interpreters.create()
+        try:
+            # Both interpreters load and use simplejson
+            _interpreters.run_string(interp1,
+                "import simplejson; simplejson.dumps([1])")
+            _interpreters.run_string(interp2,
+                "import simplejson; simplejson.dumps([2])")
+
+            # Destroy the first interpreter
+            _interpreters.destroy(interp1)
+            interp1 = None
+
+            # Second interpreter must still work correctly
+            _interpreters.run_string(interp2, """
+import simplejson
+assert simplejson.dumps({"still": "works"}) == '{"still": "works"}'
+assert simplejson.loads('{"still": "works"}') == {"still": "works"}
+""")
+        finally:
+            if interp1 is not None:
+                _interpreters.destroy(interp1)
+            _interpreters.destroy(interp2)
+
+    @skip_if_speedups_missing
+    @unittest.skipIf(sys.version_info < (3, 13),
+                     "heap types require Python 3.13+")
+    def test_subinterpreter_heap_types(self):
+        """Verify types are heap types inside subinterpreters."""
+        self._run_in_subinterp("""
+from simplejson._speedups import make_scanner, make_encoder
+# Py_TPFLAGS_HEAPTYPE = 1 << 9
+assert make_scanner.__flags__ & (1 << 9), "Scanner should be heap type"
+assert make_encoder.__flags__ & (1 << 9), "Encoder should be heap type"
+""")

--- a/simplejson/tests/test_subinterpreters.py
+++ b/simplejson/tests/test_subinterpreters.py
@@ -10,20 +10,7 @@ import sys
 import unittest
 from unittest import TestCase
 
-from simplejson import encoder
-
-
-def has_speedups():
-    return encoder.c_make_encoder is not None
-
-
-def skip_if_speedups_missing(func):
-    def wrapper(*args, **kwargs):
-        if not has_speedups():
-            raise unittest.SkipTest("C Extension not available")
-        return func(*args, **kwargs)
-
-    return wrapper
+from simplejson.tests._helpers import skip_if_speedups_missing
 
 
 @unittest.skipIf(sys.version_info < (3, 12),


### PR DESCRIPTION
## Summary

Fixes SIGSEGV crashes in the C extension on Python 3.14 free-threaded
builds (`cp314t`), modernizes `_speedups.c` to CPython's current
conventions, deduplicates the parser state machine across the Py2
bytes / unicode paths, and adds CI coverage that actually catches
regressions in this area going forward.

Python 2.7 compatibility is preserved throughout. All Python-3-only
changes are guarded by `#if PY_VERSION_HEX >= 0x030D0000` or
`#if PY_MAJOR_VERSION >= 3` as appropriate.

## Root-cause fix for the `cp314t` SIGSEGV

- **Heap types via `PyType_FromModuleAndSpec`** on 3.13+. `Scanner`
  and `Encoder` are no longer static `PyTypeObject`s; proper
  `Py_DECREF(tp)` in dealloc and `Py_VISIT(Py_TYPE(self))` in
  traverse. Static types are fundamentally incompatible with
  `Py_MOD_GIL_NOT_USED`, which is the direct cause of the 3.14t
  crash.
- `Py_mod_gil = Py_MOD_GIL_NOT_USED` declared unconditionally on
  3.13+, matching CPython's own `_json`.
- Subinterpreter support via `Py_mod_multiple_interpreters =
  Py_MOD_PER_INTERPRETER_GIL_SUPPORTED`.
- Removed the `is_gil_enabled()` Python-side guard that previously
  disabled C speedups under free-threading entirely. The speedups
  are now the default on 3.14t.
- Latent UB fix in `encoder_new`: `-1LL << n` (undefined in C for
  any negative operand) replaced with `-(long long)((1ULL << n) - 1ULL) - 1LL`,
  which is defined over 1..63 and produces `LLONG_MIN` at n == 63.
  Caught by the new `test_debug_build` CI job under
  `-Werror=shift-negative-value`.

## Unified module state and multi-phase init

One `_speedups_state` struct, used on every Python version.

- On 3.13+ it's allocated per-module via PEP 489 multi-phase init so
  each subinterpreter gets its own copy.
- On older versions it's a single static instance
  (`_speedups_static_state`) that serves the whole process.
- `get_speedups_state(module_ref)` has the same signature everywhere;
  call sites don't branch on `PY_VERSION_HEX`.
- Multi-phase init (`Py_mod_exec` slot) is used on **all** Python
  3.5+, not just 3.13+, so there's one module-init code path for
  modern Python 3. Python 2.7 and 3.3/3.4 retain single-phase init.
- `Scanner`/`Encoder` instances carry `module_ref` uniformly. On
  3.13+ it comes from `PyType_GetModuleByDef`; on older versions
  it's a borrowed pointer to the module object captured at init
  time via `_speedups_module`.
- 14 interned string constants, `RawJSONType`, `JSONDecodeError`,
  `JSON_itemgetter0`, and 4 new cached attribute names
  (`for_json`, `_asdict`, `sort`, `encoded_json`) all live in state.
- Both type fields (`PyScannerType`, `PyEncoderType`) live in the
  struct on every Python version; on pre-3.13 they're borrowed
  pointers to the static `PyTypeObject` bodies, and the type-check
  macros route through `_speedups_static_state.PyScannerType`
  instead of through a forward-declared file-scope symbol.

## Helper signature cleanup

Every internal helper that needs state takes `_speedups_state *state`
as its **first** argument:

```c
raise_errmsg(state, msg, s, end)
_encoded_const(state, obj)
is_raw_json(state, obj)
join_list_unicode(state, lst)
join_list_string(state, lst)
scanstring_unicode(state, pystr, end, strict, next_end_ptr)
scanstring_str(state, pystr, end, encoding, strict, next_end_ptr)
flush_accumulator(state, acc)
JSON_Accu_Accumulate(state, acc, unicode)
JSON_Accu_FinishAsList(state, acc)
_steal_accumulate(state, accu, stolen)
```

The convenience macros `RAISE_ERRMSG`, `ENCODED_CONST`,
`IS_RAW_JSON`, `JOIN_LIST_UNICODE`, `SCANSTRING_UNICODE` — previously
present to paper over two sets of function signatures — are all
deleted. Local variable naming is consistent (`state`, never `_st`).
`JSON_Accu` no longer carries a state pointer; state flows through
`Accumulate` / `FinishAsList` / `flush_accumulator` /
`_steal_accumulate` as an explicit parameter.

## Templated parser state machine

The five near-identical `scan_once_{str,unicode}`,
`_parse_object_{str,unicode}`, `_parse_array_{str,unicode}`,
`_match_number_{str,unicode}` function pairs are now generated from a
single source of truth in `simplejson/_speedups_scan.h`, which is
`#include`d twice from `_speedups.c` — once for the unicode variant
and once on Python 2 for the bytes variant. The differences between
variants (character reads, length/data accessors, substring creation,
fast paths for int/float parsing) are parameterized via a small set
of macros. Python-2-specific fast paths (`PyOS_string_to_double`,
`PyInt_FromString`) are preserved via four inline helper functions.

**`scanstring_str` and `scanstring_unicode` are intentionally not
templated** because `scanstring_str` has Py2-specific hybrid return-
type logic (returns `bytes` when the input is ASCII-only, `unicode`
otherwise) that's structurally different from the always-unicode
flow. Left as future work in a follow-up PR.

The template file has a `#define JSON_SPEEDUPS_SCAN_INCLUDING 1`
gate so that accidentally including it from anywhere other than
`_speedups.c` is a compile-time `#error`.

## Python side

- `simplejson/compat.py`, `__init__.py`, `encoder.py`, `scanner.py`,
  `decoder.py`: removed the `is_gil_enabled()` runtime guard. That
  check was a temporary workaround disabling the C extension on
  free-threaded Python; now that the extension is safe under
  `Py_MOD_GIL_NOT_USED`, the Python-side gate is gone and `cp314t`
  actually exercises the C path.
- `PyUnicode_READY` overridden as a no-op on Python 3.12+ (PEP 623
  made it a no-op, and it's scheduled for removal).
- Two pre-existing `-Wshadow` warnings fixed (inner `digit` locals
  shadowing `digit` from `longintrepr.h`; inner `newobj` shadowing
  an outer declaration in `encoder_listencode_obj`).
- `SIZEOF_LONG_LONG` (a Python-private pyconfig macro) replaced
  with `sizeof(long long) * CHAR_BIT`.
- `scanner_new` gained a local `LOAD_ATTR` macro that consolidates
  the repeated getattr-or-bail boilerplate.
- `encoder_new`'s 20-char `"OOOOOOOOOOOOOOOOOOOO"` format string is
  now constructed from per-argument pieces so each `"O"` has a
  comment naming its parameter.
- `encoder_listencode_obj` extracted an `encoder_steal_encode()`
  helper that handles the `for_json` / `_asdict` recursive-encode
  dance in one place with an `as_dict` flag selecting between
  `encoder_listencode_obj` and `encoder_listencode_dict` (plus
  TypeError on non-dict).
- Cached hot-path attribute names in state
  (`state->JSON_attr_{for_json,asdict,sort,encoded_json}`), so the
  encoder uses `PyObject_GetAttr` with a pre-interned name instead
  of `PyObject_GetAttrString` (which interns the C literal on every
  call).
- Dead `PY3_UNUSED` macro removed.
- Pre-3.13 `static PyTypeObject PyScannerType;` tentative forward
  declarations removed; type-check macros route through state.
- `maybe_quote_bigint` inverted for an early return on the
  common `int_as_string_bitcount is None` fast path.
- Two `-Wdeclaration-after-statement` sites fixed; the file now
  compiles cleanly under strict C89.
- `PyObject_CallNoArgs` / `PyObject_CallOneArg` compat macros lost
  their trailing semicolons so they're usable in expression
  contexts.
- Python 2 `init_speedups_state` now calls
  `reset_speedups_state_constants` to clear any prior values before
  repopulating, so the static state can be re-initialized safely
  (defensive; extension module reload doesn't normally re-run init
  on multi-phase modules, but subinterpreter imports on 3.5-3.11
  can).

## Tests

### New: `simplejson/tests/test_free_threading.py`

`TestFreeThreading` (4 tests): 8 threads × 500 iters each, covering
concurrent encode, concurrent decode, mixed encode/decode, and a
single shared `JSONEncoder`/`JSONDecoder` instance exercised by
many threads. Designed to surface data races under `PYTHON_GIL=0`.

### New: `simplejson/tests/test_subinterpreters.py`

`TestSubinterpreters` (6 tests, 3.12+ only): import, encode, decode,
3 concurrent subinterpreters, state independence across destroy,
and heap types inside a subinterpreter.

### New: `simplejson/tests/test_speedups.py::TestHeapTypes` (3.13+)

Verifies `Py_TPFLAGS_HEAPTYPE`, GC tracking, and correct
round-tripping.

### New: `simplejson/tests/test_speedups.py::TestRefcountLeaks` (debug builds)

Guarded by `@skipUnless(hasattr(sys, 'gettotalrefcount'))`. Covers
`dumps`/`loads`, `Scanner`/`Encoder` construction, and the error
path in `scanner_new`/`encoder_new` (`BadBool` triggers bail
partway through). Uses a two-phase measurement — phase 1 absorbs
CPython 3.14 specializer noise, phase 2 must be near zero — to
avoid flakiness on modern Python debug builds.

### New: `simplejson/tests/test_bitsize_int_as_string.py::test_boundary_at_max_bitcount`

Regression test for the `-1LL << n` UB fix; exercises `n = 1, 8,
31, 32, 62, 63` and both `±(2**n)` boundaries.

### Consolidated: `simplejson/tests/_helpers.py`

`has_speedups()` and `skip_if_speedups_missing()` moved out of the
three test files that used to duplicate them.

## CI (`.github/workflows/build-and-deploy.yml`)

### New job: `test_free_threading`

Runs on Python `3.14t`:

- **Asserts `sysconfig.Py_GIL_DISABLED == 1`** so the job fails
  loudly if `setup-python` ever hands us a GIL-enabled build under
  the `3.14t` moniker.
- Imports `simplejson._speedups` under `PYTHON_GIL=0` with
  `-W error::RuntimeWarning`.
- **Asserts `simplejson.encoder.c_make_encoder is make_encoder`**
  (and the same for scanner) so a silently-broken wheel — one that
  imports fine but leaves `c_make_encoder is None` — doesn't make
  every C-extension test skip quietly.
- Runs the full test suite with and without `PYTHON_GIL=0`.

### New job: `test_debug_build` (matrixed)

Matrix over `standard` and `free-threaded` variants, both installed
via `uv python install cpython-3.14.4+debug` and
`cpython-3.14.4+freethreaded+debug` from python-build-standalone
(~10 seconds per variant, no custom build). Each variant:

- Verifies `sys.gettotalrefcount` is present.
- Compiles `_speedups.c` with `-Wall -Wextra -Wshadow
  -Wstrict-prototypes -Werror` (caught the shift-negative-value UB).
- Verifies the C speedups are actually wired in.
- Runs the full test suite; `TestRefcountLeaks` auto-enables on
  the debug interpreter.

The free-threaded variant additionally:

- Asserts `sysconfig.Py_GIL_DISABLED == 1`.
- Re-runs the suite with `PYTHON_GIL=0`.

### Wheel / sdist jobs

- `CIBW_ENABLE: "cpython-freethreading"` removed (deprecated in
  cibuildwheel 3.4; free-threaded builds are on by default).
- `CIBW_SKIP: "pp*"` removed from the v3.4.1 step (PyPy is off by
  default in 3.x; explicit skip is now an error). Kept on the
  v1.12.0 step for Python 2.7.
- Linux wheel builds split by architecture (`x86_64`, `aarch64`,
  `ppc64le`) into separate matrix entries.
- Python 2.7 wheels restricted to `x86_64` (QEMU-based 2.7 builds
  on other arches are no longer viable).
- Aggregate gate jobs (`Build wheels on {ubuntu,windows,macos}-
  latest`) preserve the job names required by existing branch
  protection rules. The ubuntu gate waits for `test_pure_python`,
  `test_free_threading`, and `test_debug_build`.

### Dependency bumps

- `pypa/cibuildwheel` v3.2.1 → v3.4.1
- `actions/checkout` v4 → v6
- `actions/cache` v4 → v5
- `docker/setup-qemu-action` v3 → v4
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `astral-sh/setup-uv` pinned to v8.0.0 (new job dependency)

## AGENTS.md

New top-level file collecting the tribal knowledge accumulated in
this PR that isn't obvious from reading the source: using uv +
python-build-standalone for alternate Python variants locally, how
to debug CI failures when only the annotations are visible, the
cibuildwheel version gotchas, why `importlib.reload(_speedups)`
does not actually re-run `module_exec`, the two-phase measurement
trick for `TestRefcountLeaks` on 3.14 debug, the `_speedups_scan.h`
usage contract, the invariant that type fields must not be
`Py_CLEAR`ed in `reset_speedups_state_constants`, and the
`REQUIRE_SPEEDUPS=1` scope limitation (build-only).

## Test plan

- [x] Full test suite passes on Python 3.11 release (169 tests)
- [x] Full test suite passes on Python 3.14.4 **debug** (344 tests
      including `TestRefcountLeaks`)
- [x] Full test suite passes on Python 3.14.4 **free-threaded debug**
      both with the GIL on and with `PYTHON_GIL=0` (344 tests)
- [x] Extension compiles cleanly under `-Wall -Wextra -Wshadow
      -Wstrict-prototypes -Werror` on all of 3.10 / 3.11 / 3.12 /
      3.13 / 3.14.4 / 3.14.4 debug / 3.14.4 free-threaded debug
- [x] File is also clean under `-Wdeclaration-after-statement`
      (strict C89 mixed-decls)
- [x] `PYTHON_GIL=0 python -c "import simplejson._speedups"` emits
      no `RuntimeWarning` on 3.14t
- [x] `_speedups.so` refcount stable across 32k threaded ops and
      5k failing constructions
- [x] `int_as_string_bitcount` boundary exercised for n = 1, 8, 31,
      32, 62, 63 including the `LLONG_MIN` edge case at n == 63
- [x] sdist contains both `_speedups.c` and `_speedups_scan.h`

## File-level diff

| File | Before | After | Δ |
|---|---:|---:|---:|
| `simplejson/_speedups.c` | 3841 | ~2920 | **−921** |
| `simplejson/_speedups_scan.h` | (new) | 539 | +539 |

Net: the C extension source is ~380 lines smaller despite gaining
heap types, per-module state, multi-phase init, four new test
suites, and a templated parser body.

## Known limits / future work

- **`scanstring_str` / `scanstring_unicode` templating**: the
  remaining big duplication (~200 lines). Blocked on Py2 hybrid
  return-type handling; deferred to a follow-up PR.
- **ThreadSanitizer** on a TSan-instrumented CPython: would give
  true race detection on the free-threaded path. Requires a
  custom CPython build; not wired up.
- **Suppression-clean valgrind** with `PYTHONMALLOC=malloc`: would
  give true leak detection. Requires a custom CPython build with
  `--with-valgrind`; not wired up. The refcount regression tests
  on the debug job catch most of what valgrind would.

https://claude.ai/code/session_01EoWzUsmRRvrZBF2nwQhF95