### PR TITLE
Encoder parity fixes (for_json/_asdict) and TSan stress CI job

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -152,11 +152,12 @@ jobs:
         run: PYTHON_GIL=0 .venv/bin/python -m simplejson.tests._cibw_runner .
 
   test_tsan:
-    name: TSan stress (CPython ${{ env.CPYTHON_REF }} free-threaded)
+    name: TSan stress (CPython v3.14.0 free-threaded)
     runs-on: ubuntu-latest
     env:
-      # Pinned so the cache key is stable; bump when moving to a newer
-      # CPython (cache is keyed on this + clang version + script hash).
+      # Keep in sync with the name above. Pinned so the cache key is stable;
+      # bump when moving to a newer CPython (cache is keyed on this + clang
+      # version + script hash).
       CPYTHON_REF: v3.14.0
       TSAN_ROOT: /home/runner/.cache/py-tsan-ft
     steps:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -151,6 +151,57 @@ jobs:
         if: matrix.variant == 'free-threaded'
         run: PYTHON_GIL=0 .venv/bin/python -m simplejson.tests._cibw_runner .
 
+  test_tsan:
+    name: TSan stress (CPython ${{ env.CPYTHON_REF }} free-threaded)
+    runs-on: ubuntu-latest
+    env:
+      # Pinned so the cache key is stable; bump when moving to a newer
+      # CPython (cache is keyed on this + clang version + script hash).
+      CPYTHON_REF: v3.14.0
+      TSAN_ROOT: /home/runner/.cache/py-tsan-ft
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential clang lld \
+            libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+            libsqlite3-dev libffi-dev liblzma-dev
+      - name: Record clang version (for cache key)
+        id: clang
+        run: |
+          version=$(clang --version | head -1 | awk '{print $NF}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Restore TSan CPython build
+        id: cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.TSAN_ROOT }}
+          key: tsan-cpython-${{ env.CPYTHON_REF }}-${{ runner.os }}-clang${{ steps.clang.outputs.version }}-${{ hashFiles('scripts/run_tsan_stress.sh') }}
+      - name: Build TSan CPython (cache miss only, ~15 min)
+        id: build
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./scripts/run_tsan_stress.sh build
+      - name: Save TSan CPython build
+        # Save the built CPython whether the later stress test passes or
+        # fails, so a regression doesn't force a 15-min rebuild next run.
+        # Skip save on cache hit (nothing new) or if the build itself failed
+        # (would cache a broken install).
+        if: always() && steps.cache.outputs.cache-hit != 'true' && steps.build.outcome == 'success'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.TSAN_ROOT }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+      - name: Install simplejson and run stress test
+        run: ./scripts/run_tsan_stress.sh test
+      - name: Upload TSan report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tsan-report
+          path: tsan_report.txt
+
   build_wheels_py27:
     name: Build Python 2.7 wheels (linux x86_64)
     runs-on: ubuntu-latest
@@ -314,7 +365,7 @@ jobs:
   # Aggregate gate jobs to match branch protection rule names
   gate_ubuntu:
     name: Build wheels on ubuntu-latest
-    needs: [build_wheels, build_wheels_py27, build_pyodide_wheel, test_pure_python, test_prerelease, test_free_threading, test_debug_build, test_pep517_build]
+    needs: [build_wheels, build_wheels_py27, build_pyodide_wheel, test_pure_python, test_prerelease, test_free_threading, test_debug_build, test_pep517_build, test_tsan]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All ubuntu-latest checks passed"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /build
 /dist
 /docs
+/tsan_report.txt

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-Version 4.0.0 released 2026-04-12
+Version 4.0.0
 
 * simplejson 4 requires Python 2.7 or Python 3.8+. Older Python
   versions (2.5, 2.6, 3.0-3.7) are no longer supported. pip will
@@ -28,12 +28,30 @@ Version 4.0.0 released 2026-04-12
   - Fix member table copy-paste, exception clobbering, missing Py_VISIT
   - Fix error-as-truthy bugs in maybe_quote_bigint and is_raw_json
   - Fix iterable_as_array swallowing MemoryError and KeyboardInterrupt
+  - Fix for_json and _asdict swallowing MemoryError, KeyboardInterrupt,
+    and other non-AttributeError exceptions raised by user __getattr__
   https://github.com/simplejson/simplejson/pull/355
   https://github.com/simplejson/simplejson/pull/356
   https://github.com/simplejson/simplejson/pull/357
   https://github.com/simplejson/simplejson/pull/358
   https://github.com/simplejson/simplejson/pull/359
   https://github.com/simplejson/simplejson/pull/360
+  https://github.com/simplejson/simplejson/pull/373
+
+* C/Python parity fixes:
+  - Fix C scanstring off-by-one bounds checks that caused truncated
+    or boundary \uXXXX escapes to raise "Invalid \\uXXXX escape
+    sequence" instead of "Unterminated string", and report error
+    position at the 'u' instead of the leading backslash. The C and
+    Python decoders now agree on exception class, message, and
+    position across all tested edge cases.
+  - Align the Python encoder's dispatch order with the C encoder for
+    objects that define _asdict(). Previously a list/tuple/dict
+    subclass with an _asdict() method encoded as its container type
+    under the Python encoder and as the _asdict() return value under
+    the C encoder; both now check _asdict() before list/tuple/dict.
+    for_json() continues to outrank _asdict() in both.
+  https://github.com/simplejson/simplejson/pull/372
 
 * C extension performance and correctness improvements:
   - Add PyDict_Next fast path for unsorted exact-dict encoding,

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -71,6 +71,12 @@ Version 4.0.0
   leak detection, and GIL-disabled mode.
   https://github.com/simplejson/simplejson/pull/343
 
+* Added a ThreadSanitizer (TSan) stress test CI job. Builds a
+  TSan-instrumented free-threaded CPython (cached between runs) and
+  runs a concurrent stress test script against the C extension to
+  catch data races under free-threading.
+  https://github.com/simplejson/simplejson/pull/373
+
 * Replace deprecated license classifiers with SPDX license expression
   https://github.com/simplejson/simplejson/pull/347
 

--- a/scripts/run_tsan_stress.sh
+++ b/scripts/run_tsan_stress.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Build a TSan-instrumented free-threaded CPython (if needed) and run the
+# simplejson stress test under it. Re-runs are cheap: clone, build, and
+# install are skipped when artifacts are already present.
+#
+# Intended for local use and future CI integration. In CI, cache
+# ${TSAN_ROOT} keyed on ${CPYTHON_REF} to skip the CPython rebuild.
+#
+# Required build deps (Debian/Ubuntu):
+#   apt install -y build-essential git libssl-dev zlib1g-dev libbz2-dev \
+#                  libreadline-dev libsqlite3-dev libffi-dev liblzma-dev
+
+set -euo pipefail
+
+: "${CPYTHON_REF:=v3.14.0}"
+: "${CPYTHON_REPO:=https://github.com/python/cpython.git}"
+: "${TSAN_ROOT:=${HOME}/.cache/py-tsan-ft}"
+: "${TSAN_OPTIONS:=halt_on_error=0 second_deadlock_stack=1 history_size=7 handle_segv=0}"
+
+# TSan's shadow-memory layout expects PIE binaries to land in a narrow range.
+# Modern Linux kernels (>=5.x) randomize mmap widely enough that sanitizer-
+# instrumented programs (including CPython's build-time _freeze_module helper)
+# crash with "unexpected memory mapping". Disabling ASLR for the process with
+# setarch -R (ADDR_NO_RANDOMIZE personality, no root needed) sidesteps this.
+NO_ASLR=(setarch "$(uname -m)" -R)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${SIMPLEJSON_ROOT:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
+: "${STRESS_SCRIPT:=${SIMPLEJSON_ROOT}/tsan_stress_simplejson.py}"
+: "${REPORT:=${SIMPLEJSON_ROOT}/tsan_report.txt}"
+
+TSAN_SRC="${TSAN_ROOT}/src-${CPYTHON_REF}"
+TSAN_PREFIX="${TSAN_ROOT}/install-${CPYTHON_REF}"
+PY="${TSAN_PREFIX}/bin/python3"
+
+log() { printf '==> %s\n' "$*"; }
+
+ensure_source() {
+    if [[ -d "${TSAN_SRC}/.git" ]]; then
+        log "cpython source present at ${TSAN_SRC}"
+        return
+    fi
+    log "cloning ${CPYTHON_REPO}@${CPYTHON_REF} -> ${TSAN_SRC}"
+    mkdir -p "${TSAN_ROOT}"
+    git clone --depth 1 --branch "${CPYTHON_REF}" "${CPYTHON_REPO}" "${TSAN_SRC}"
+}
+
+python_is_tsan_ft() {
+    [[ -x "${PY}" ]] || return 1
+    "${PY}" - <<'PY' >/dev/null 2>&1 || return 1
+import sys, sysconfig
+gil = sysconfig.get_config_var('Py_GIL_DISABLED')
+cflags = sysconfig.get_config_var('CFLAGS') or ''
+assert gil == 1, f'Py_GIL_DISABLED={gil!r}'
+assert '-fsanitize=thread' in cflags, f'no -fsanitize=thread in CFLAGS'
+PY
+}
+
+build_cpython() {
+    if python_is_tsan_ft; then
+        log "tsan free-threaded python already built at ${PY}"
+        return
+    fi
+    # A previous failed build leaves .o files compiled with a different CC;
+    # make clean ensures the rebuild is consistent with the chosen compiler.
+    if [[ -f "${TSAN_SRC}/Makefile" ]]; then
+        log "cleaning previous build artifacts in ${TSAN_SRC}"
+        (cd "${TSAN_SRC}" && make -s distclean 2>/dev/null || true)
+    fi
+    log "configuring CPython (--disable-gil --with-thread-sanitizer)"
+    local jobs
+    jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+    # CPython's own TSan CI uses clang; gcc's TSan mishandles CPython's
+    # frozen getpath (corrupted wchar_t decode at startup). Prefer clang
+    # when available and fall back to the default compiler otherwise.
+    local cc_args=()
+    if command -v clang >/dev/null 2>&1; then
+        cc_args=(CC=clang CXX=clang++)
+        log "using clang for TSan build"
+    else
+        log "WARNING: clang not found; falling back to default CC (expect frozen-getpath crash with gcc)"
+    fi
+    (
+        cd "${TSAN_SRC}"
+        # Several configure AC_RUN_IFELSE tests fail under -fsanitize=thread
+        # because the sanitizer runtime isn't linked into the tiny test
+        # programs. Preset the autoconf cache vars so configure trusts the
+        # test result instead of executing the binary.
+        ac_cv_buggy_getaddrinfo=no \
+        ac_cv_strftime_c99_support=yes \
+        ./configure \
+            "${cc_args[@]}" \
+            --disable-gil \
+            --with-thread-sanitizer \
+            --prefix="${TSAN_PREFIX}"
+        log "building (make -j${jobs})"
+        "${NO_ASLR[@]}" make -j"${jobs}"
+        log "installing -> ${TSAN_PREFIX}"
+        "${NO_ASLR[@]}" make install
+    )
+    "${NO_ASLR[@]}" "${PY}" -m ensurepip --upgrade
+    "${NO_ASLR[@]}" "${PY}" -m pip install --upgrade pip setuptools wheel
+}
+
+install_simplejson() {
+    log "installing simplejson (editable) into ${TSAN_PREFIX}"
+    REQUIRE_SPEEDUPS=1 "${NO_ASLR[@]}" "${PY}" -m pip install --no-build-isolation -e "${SIMPLEJSON_ROOT}"
+    "${NO_ASLR[@]}" "${PY}" -c 'from simplejson._speedups import make_scanner, make_encoder; print("speedups loaded")'
+}
+
+run_stress() {
+    log "running stress test -> ${REPORT}"
+    : > "${REPORT}"
+    PYTHON_GIL=0 TSAN_OPTIONS="${TSAN_OPTIONS}" \
+        "${NO_ASLR[@]}" "${PY}" "${STRESS_SCRIPT}" 2> "${REPORT}" || true
+    if grep -q 'WARNING: ThreadSanitizer' "${REPORT}"; then
+        local count
+        count=$(grep -c 'WARNING: ThreadSanitizer' "${REPORT}")
+        log "tsan detected ${count} warning(s) - see ${REPORT}"
+        exit 1
+    fi
+    log "no tsan warnings"
+}
+
+PHASE="${1:-all}"
+case "${PHASE}" in
+    build)
+        ensure_source
+        build_cpython
+        ;;
+    test)
+        install_simplejson
+        run_stress
+        ;;
+    all)
+        ensure_source
+        build_cpython
+        install_simplejson
+        run_stress
+        ;;
+    *)
+        echo "usage: $0 [build|test|all]" >&2
+        exit 2
+        ;;
+esac

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -750,8 +750,15 @@ _call_json_method(PyObject *obj, PyObject *method_name, PyObject **result)
      * avoids the char-to-interned-unicode conversion on every call. */
     PyObject *method = PyObject_GetAttr(obj, method_name);
     if (method == NULL) {
-        PyErr_Clear();
-        return 0;
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
+            return 0;
+        }
+        /* Non-AttributeError from __getattr__ (e.g. MemoryError,
+         * KeyboardInterrupt): propagate via NULL result so the caller
+         * forwards the pending exception to encoder_steal_encode. */
+        *result = NULL;
+        return 1;
     }
     if (PyCallable_Check(method)) {
         PyObject *tmp = PyObject_CallNoArgs(method);

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -542,8 +542,6 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     for_json = _for_json and call_method(value, 'for_json')
                     if for_json:
                         chunks = _iterencode(for_json[0], _current_indent_level)
-                    elif isinstance(value, list):
-                        chunks = _iterencode_list(value, _current_indent_level)
                     else:
                         _asdict = _namedtuple_as_object and call_method(value, '_asdict')
                         if _asdict:
@@ -552,6 +550,8 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                                 raise TypeError("_asdict() must return a dict, not %s" % (type(dct).__name__,))
                             chunks = _iterencode_dict(dct,
                                                       _current_indent_level)
+                        elif isinstance(value, list):
+                            chunks = _iterencode_list(value, _current_indent_level)
                         elif _tuple_as_array and isinstance(value, tuple):
                             chunks = _iterencode_list(value, _current_indent_level)
                         elif isinstance(value, _dict_types):
@@ -673,8 +673,6 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     for_json = _for_json and call_method(value, 'for_json')
                     if for_json:
                         chunks = _iterencode(for_json[0], _current_indent_level)
-                    elif isinstance(value, list):
-                        chunks = _iterencode_list(value, _current_indent_level)
                     else:
                         _asdict = _namedtuple_as_object and call_method(value, '_asdict')
                         if _asdict:
@@ -683,6 +681,8 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                                 raise TypeError("_asdict() must return a dict, not %s" % (type(dct).__name__,))
                             chunks = _iterencode_dict(dct,
                                                       _current_indent_level)
+                        elif isinstance(value, list):
+                            chunks = _iterencode_list(value, _current_indent_level)
                         elif _tuple_as_array and isinstance(value, tuple):
                             chunks = _iterencode_list(value, _current_indent_level)
                         elif isinstance(value, _dict_types):
@@ -726,9 +726,6 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             if for_json:
                 for chunk in _iterencode(for_json[0], _current_indent_level):
                     yield chunk
-            elif isinstance(o, list):
-                for chunk in _iterencode_list(o, _current_indent_level):
-                    yield chunk
             else:
                 _asdict = _namedtuple_as_object and call_method(o, '_asdict')
                 if _asdict:
@@ -736,6 +733,9 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     if not isinstance(dct, dict):
                         raise TypeError("_asdict() must return a dict, not %s" % (type(dct).__name__,))
                     for chunk in _iterencode_dict(dct, _current_indent_level):
+                        yield chunk
+                elif isinstance(o, list):
+                    for chunk in _iterencode_list(o, _current_indent_level):
                         yield chunk
                 elif (_tuple_as_array and isinstance(o, tuple)):
                     for chunk in _iterencode_list(o, _current_indent_level):

--- a/simplejson/tests/test_for_json.py
+++ b/simplejson/tests/test_for_json.py
@@ -95,3 +95,34 @@ class TestForJson(unittest.TestCase):
     def test_raises_typeerror_if_for_json_not_true_with_object(self):
         self.assertRaises(TypeError, json.dumps, ForJson())
         self.assertRaises(TypeError, json.dumps, ForJson(), for_json=False)
+
+    def test_getattr_exception_propagates(self):
+        # Regression: _call_json_method used to PyErr_Clear() unconditionally
+        # after PyObject_GetAttr() failed, swallowing MemoryError,
+        # KeyboardInterrupt, and any other non-AttributeError raised by a
+        # user __getattr__. Same bug class as commit d3ecab5 (iterable_as_array).
+        class BadAttr(object):
+            def __init__(self, attr, exc):
+                self.attr = attr
+                self.exc = exc
+            def __getattr__(self, name):
+                if name == self.attr:
+                    raise self.exc('from __getattr__: ' + name)
+                raise AttributeError(name)
+
+        for exc_type in (MemoryError, RuntimeError):
+            self.assertRaises(
+                exc_type,
+                json.dumps, BadAttr('for_json', exc_type), for_json=True)
+            self.assertRaises(
+                exc_type,
+                json.dumps, BadAttr('_asdict', exc_type),
+                namedtuple_as_object=True)
+
+        # AttributeError from __getattr__ must still be treated as
+        # "method not present" and fall through silently.
+        class NoJsonMethods(object):
+            def __getattr__(self, name):
+                raise AttributeError(name)
+        self.assertRaises(
+            TypeError, json.dumps, NoJsonMethods(), for_json=True)

--- a/simplejson/tests/test_namedtuple.py
+++ b/simplejson/tests/test_namedtuple.py
@@ -153,3 +153,54 @@ class TestNamedTuple(unittest.TestCase):
         # assert(!PyErr_Occurred()) that could fire later on.
         with self.assertRaises(TypeError):
             json.dumps({23: fake}, namedtuple_as_object=True, for_json=False)
+
+    def test_asdict_dispatch_order(self):
+        # Regression: the Python encoder used to check isinstance(o, list)
+        # BEFORE _asdict(), so a list subclass that defines _asdict()
+        # encoded as a plain list under Py and as an object under C.
+        # Consolidated on C's order: _asdict() takes precedence over
+        # list/tuple/dict container checks. for_json still wins over
+        # _asdict in both backends.
+        #
+        # The _cibw_runner harness runs the whole test suite once with
+        # the C speedups active and once with them disabled, so a single
+        # assertion here covers both backends.
+        class ListAsdict(list):
+            def _asdict(self):
+                return {'from_asdict': list(self)}
+
+        class TupleAsdict(tuple):
+            def _asdict(self):
+                return {'from_asdict': list(self)}
+
+        class DictAsdict(dict):
+            def _asdict(self):
+                return {'from_asdict': dict(self)}
+
+        class ListBoth(list):
+            def _asdict(self):
+                return {'from_asdict': True}
+            def for_json(self):
+                return {'from_for_json': True}
+
+        self.assertEqual(
+            {'from_asdict': [10, 20]},
+            json.loads(json.dumps(ListAsdict([10, 20]))))
+        self.assertEqual(
+            {'from_asdict': [1, 2]},
+            json.loads(json.dumps(TupleAsdict((1, 2)))))
+        self.assertEqual(
+            {'from_asdict': {'x': 1}},
+            json.loads(json.dumps(DictAsdict(x=1))))
+        # Nested inside a plain list.
+        self.assertEqual(
+            [{'from_asdict': [10]}],
+            json.loads(json.dumps([ListAsdict([10])])))
+        # Nested inside a plain dict.
+        self.assertEqual(
+            {'k': {'from_asdict': [10]}},
+            json.loads(json.dumps({'k': ListAsdict([10])})))
+        # for_json must still outrank _asdict.
+        self.assertEqual(
+            {'from_for_json': True},
+            json.loads(json.dumps(ListBoth([1]), for_json=True)))

--- a/tsan_stress_simplejson.py
+++ b/tsan_stress_simplejson.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""TSan stress test for simplejson._speedups.
+
+================================================================================
+Building a TSan + free-threaded CPython (one-time)
+================================================================================
+    git clone https://github.com/python/cpython.git cpython-tsan
+    cd cpython-tsan
+    ./configure --disable-gil --with-thread-sanitizer \
+                --prefix=$HOME/py-tsan-ft
+    make -j$(nproc) && make install
+    $HOME/py-tsan-ft/bin/python3 -m pip install -e /home/bob/src/simplejson
+
+================================================================================
+Running this script under TSan
+================================================================================
+    cd /home/bob/src/simplejson
+    PYTHON_GIL=0 \
+      TSAN_OPTIONS='halt_on_error=0 second_deadlock_stack=1 history_size=7' \
+      $HOME/py-tsan-ft/bin/python3 tsan_stress_simplejson.py \
+      2> tsan_report.txt
+
+    # Triage:
+    /ft-review-toolkit:explore . tsan tsan_report.txt
+
+================================================================================
+Configuration (environment variables)
+================================================================================
+    TSAN_THREADS     concurrent workers (default: cpu_count or 8)
+    TSAN_ITERATIONS  calls per worker per scenario (default 2000; auto-lowered
+                     on TSan builds)
+    TSAN_DURATION    approximate wall-clock seconds per scenario (default 2.5)
+    TSAN_TIMEOUT     per-scenario hard timeout in seconds (default 60)
+
+What this exercises
+-------------------
+  - Scenario 1: N threads share ONE make_scanner() instance; each parses
+    different-but-overlapping JSON (dict/list/string cases). Targets scanner
+    s->memo (PyDict_SetItem/Clear) under concurrent scan_once().
+  - Scenario 2: N threads share ONE make_encoder() instance; each encodes
+    distinct nested dict/list objects. Targets self->markers and
+    self->key_memo mutation on concurrent calls.
+  - Scenario 3: N threads encode the SAME shared dict. Stresses the
+    Py_BEGIN_CRITICAL_SECTION(dct) path in encoder_listencode_dict.
+  - Scenario 4: N threads encode the SAME shared list. Stresses the
+    Py_BEGIN_CRITICAL_SECTION(seq) path in encoder_listencode_list.
+  - Scenario 5: Mutator thread adds/removes keys while N readers encode the
+    same dict (read-write contention on the input container).
+  - Scenario 6: Module-level hammer for scanstring + encode_basestring_ascii.
+"""
+import os
+import signal
+import sys
+import threading
+import time
+import warnings
+
+warnings.filterwarnings("ignore", ".*GIL.*")
+
+
+# --------------------------- configuration ---------------------------------- #
+
+def _env_int(name, default):
+    try:
+        v = os.environ.get(name)
+        return int(v) if v else default
+    except ValueError:
+        return default
+
+
+def _env_float(name, default):
+    try:
+        v = os.environ.get(name)
+        return float(v) if v else default
+    except ValueError:
+        return default
+
+
+def _is_tsan_build():
+    try:
+        import sysconfig
+        cflags = (sysconfig.get_config_var("CFLAGS") or "").lower()
+        ldflags = (sysconfig.get_config_var("LDFLAGS") or "").lower()
+        return "fsanitize=thread" in cflags or "fsanitize=thread" in ldflags
+    except Exception:
+        return False
+
+
+THREADS = _env_int("TSAN_THREADS", os.cpu_count() or 8)
+ITERATIONS = _env_int("TSAN_ITERATIONS", 2000)
+DURATION = _env_float("TSAN_DURATION", 2.5)
+SCENARIO_TIMEOUT = _env_int("TSAN_TIMEOUT", 60)
+
+if _is_tsan_build():
+    # TSan finds races on first occurrence; cap work to keep runtime sane.
+    THREADS = min(THREADS, 6)
+    ITERATIONS = min(ITERATIONS, 400)
+
+
+# --------------------------- import guard ----------------------------------- #
+
+try:
+    from simplejson import _speedups
+except ImportError as exc:
+    print(f"SKIP: cannot import simplejson._speedups: {exc}", file=sys.stderr)
+    sys.exit(0)
+
+missing = [
+    n for n in ("make_scanner", "make_encoder",
+                "encode_basestring_ascii", "scanstring")
+    if not hasattr(_speedups, n)
+]
+if missing:
+    print(f"SKIP: simplejson._speedups missing symbols: {missing}",
+          file=sys.stderr)
+    sys.exit(0)
+
+
+# --------------------------- shared fixtures -------------------------------- #
+
+# A minimal context object that satisfies the fields read by make_scanner().
+# Mirrors simplejson.scanner.JSONDecoder attributes accessed in Scanner init.
+import decimal
+
+
+class _ScanCtx:
+    __slots__ = (
+        "encoding", "strict", "object_hook", "object_pairs_hook",
+        "array_hook", "parse_float", "parse_int", "parse_constant", "memo",
+    )
+
+    def __init__(self):
+        self.encoding = "utf-8"
+        self.strict = True
+        self.object_hook = None
+        self.object_pairs_hook = None
+        self.array_hook = None
+        self.parse_float = float
+        self.parse_int = int
+        self.parse_constant = float
+        self.memo = {}
+
+
+def _make_shared_scanner():
+    return _speedups.make_scanner(_ScanCtx())
+
+
+def _make_shared_encoder():
+    # Matches the argument order in simplejson/encoder.py c_make_encoder call.
+    markers = {}
+    key_memo = {}
+    return _speedups.make_encoder(
+        markers,                            # markers (cycle detection)
+        lambda o: str(o),                   # default
+        _speedups.encode_basestring_ascii,  # _encoder (ascii)
+        None,                               # indent
+        ": ", ", ",                         # key_sep, item_sep
+        False,                              # sort_keys
+        False,                              # skipkeys
+        True,                               # allow_nan
+        key_memo,                           # key_memo
+        False,                              # use_decimal
+        False,                              # namedtuple_as_object
+        True,                               # tuple_as_array
+        None,                               # int_as_string_bitcount (None or positive int)
+        None,                               # item_sort_key
+        "utf-8",                            # encoding
+        False,                              # for_json
+        False,                              # ignore_nan
+        decimal.Decimal,                    # Decimal
+        False,                              # iterable_as_array
+    )
+
+
+# Varied JSON documents exercising dict / list / string / number / escapes.
+JSON_SAMPLES = [
+    b'{"a": 1, "b": [1,2,3], "c": "hello"}',
+    b'[1, 2, 3, 4, "five", null, true, false]',
+    b'{"nested": {"x": [1, {"y": [2, {"z": 3}]}]}}',
+    b'"a plain \\"quoted\\" string with \\u00e9 escapes and \\n newlines"',
+    b'{"k1":"v1","k2":"v2","k3":"v3","k4":"v4","k5":"v5"}',
+    b'[{"id":1,"name":"alice"},{"id":2,"name":"bob"},{"id":3,"name":"carol"}]',
+    b'{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8}',
+    b'{"list":[1.5, 2.5, 3.5, -0.25, 1e10, -2.3e-5]}',
+]
+JSON_SAMPLES = [s.decode("utf-8") for s in JSON_SAMPLES]
+
+
+def _make_distinct_object(i):
+    return {
+        "id": i,
+        "name": f"item-{i}",
+        "tags": ["alpha", "beta", "gamma", f"n{i}"],
+        "nested": {"x": i, "y": [i, i + 1, i + 2], "s": "x" * (i % 16)},
+        "vals": [1, 2, 3, 4, 5, i, i * 2, i * 3],
+    }
+
+
+SHARED_DICT = {
+    "a": 1, "b": 2, "c": [1, 2, 3, 4, 5],
+    "d": {"dd": "deep", "ee": [10, 20, 30]},
+    "e": "some string with \"escapes\" and \n newlines",
+    "f": True, "g": None, "h": 3.14159,
+}
+
+SHARED_LIST = [
+    1, 2, 3, "four", 5.0, None, True, False,
+    {"a": 1, "b": 2},
+    [10, 20, 30, 40],
+    "a \"quoted\" thing",
+    {"nested": {"deeper": [1, 2, 3]}},
+]
+
+
+# --------------------------- scenario plumbing ------------------------------ #
+
+def run_scenario(name, target_fns, thread_counts=None):
+    """Run a scenario in a forked child so a SEGV can't kill the parent."""
+    print(f"  Running: {name} ...", end=" ", flush=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    pid = os.fork()
+    if pid == 0:
+        try:
+            _run_scenario_threads(target_fns, thread_counts)
+            os._exit(0)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else 1
+            os._exit(code)
+        except BaseException:
+            import traceback
+            traceback.print_exc()
+            os._exit(1)
+
+    deadline = time.monotonic() + SCENARIO_TIMEOUT
+    wait_status = None
+    while time.monotonic() < deadline:
+        r_pid, status = os.waitpid(pid, os.WNOHANG)
+        if r_pid != 0:
+            wait_status = status
+            break
+        time.sleep(0.1)
+
+    if wait_status is None:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        os.waitpid(pid, 0)
+        print(f"TIMEOUT ({SCENARIO_TIMEOUT}s)")
+    elif os.WIFSIGNALED(wait_status):
+        sig = os.WTERMSIG(wait_status)
+        name_ = (signal.Signals(sig).name
+                 if sig in signal.Signals._value2member_map_ else str(sig))
+        print(f"CRASH ({name_})")
+    elif os.WIFEXITED(wait_status) and os.WEXITSTATUS(wait_status) != 0:
+        print(f"FAIL (exit {os.WEXITSTATUS(wait_status)})")
+    else:
+        print("OK")
+
+
+def _run_scenario_threads(target_fns, thread_counts=None):
+    if thread_counts is None:
+        thread_counts = [THREADS] * len(target_fns)
+
+    total = sum(thread_counts)
+    barrier = threading.Barrier(total)
+    errors = []
+    errors_lock = threading.Lock()
+
+    def wrapper(fn):
+        def wrapped():
+            try:
+                barrier.wait()
+                fn()
+            except Exception as exc:
+                with errors_lock:
+                    errors.append(repr(exc))
+        return wrapped
+
+    threads = []
+    for fn, count in zip(target_fns, thread_counts):
+        for _ in range(count):
+            threads.append(threading.Thread(target=wrapper(fn), daemon=True))
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=SCENARIO_TIMEOUT)
+
+    if errors:
+        # Print a few; data races remain the interesting output on stderr.
+        for e in errors[:5]:
+            print(f"    worker error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+# --------------------------- scenarios -------------------------------------- #
+
+def scenario_shared_scanner():
+    """N threads share ONE scanner; race on s->memo (SetItem/Clear)."""
+    scanner = _make_shared_scanner()
+    samples = JSON_SAMPLES
+
+    def worker():
+        deadline = time.monotonic() + DURATION
+        i = 0
+        for _ in range(ITERATIONS):
+            doc = samples[i % len(samples)]
+            try:
+                scanner(doc, 0)
+            except Exception:
+                pass
+            i += 1
+            if time.monotonic() > deadline:
+                break
+
+    run_scenario("shared scanner (scanner s->memo races)", [worker])
+
+
+def scenario_shared_encoder_distinct_inputs():
+    """N threads share ONE encoder; distinct objects. markers/key_memo races."""
+    encoder = _make_shared_encoder()
+
+    def make_worker(tid):
+        def worker():
+            deadline = time.monotonic() + DURATION
+            for i in range(ITERATIONS):
+                obj = _make_distinct_object(tid * 1_000_000 + i)
+                try:
+                    encoder(obj, 0)
+                except Exception:
+                    pass
+                if time.monotonic() > deadline:
+                    break
+        return worker
+
+    run_scenario(
+        "shared encoder, distinct inputs (markers / key_memo races)",
+        [make_worker(i) for i in range(THREADS)],
+        [1] * THREADS,
+    )
+
+
+def scenario_shared_encoder_shared_dict():
+    """All threads encode the SAME dict -> encoder_listencode_dict crit-sect."""
+    encoder = _make_shared_encoder()
+    shared = SHARED_DICT
+
+    def worker():
+        deadline = time.monotonic() + DURATION
+        for _ in range(ITERATIONS):
+            try:
+                encoder(shared, 0)
+            except Exception:
+                pass
+            if time.monotonic() > deadline:
+                break
+
+    run_scenario(
+        "shared encoder + shared dict (encoder_listencode_dict CS)",
+        [worker],
+    )
+
+
+def scenario_shared_encoder_shared_list():
+    """All threads encode the SAME list -> encoder_listencode_list crit-sect."""
+    encoder = _make_shared_encoder()
+    shared = SHARED_LIST
+
+    def worker():
+        deadline = time.monotonic() + DURATION
+        for _ in range(ITERATIONS):
+            try:
+                encoder(shared, 0)
+            except Exception:
+                pass
+            if time.monotonic() > deadline:
+                break
+
+    run_scenario(
+        "shared encoder + shared list (encoder_listencode_list CS)",
+        [worker],
+    )
+
+
+def scenario_mutator_vs_readers():
+    """Mutator mutates dict while readers encode it. Stresses input CS."""
+    encoder = _make_shared_encoder()
+    target = {"base": 0, "a": 1, "b": 2, "c": 3, "d": [1, 2, 3]}
+
+    def reader():
+        deadline = time.monotonic() + DURATION
+        for _ in range(ITERATIONS):
+            try:
+                encoder(target, 0)
+            except Exception:
+                pass
+            if time.monotonic() > deadline:
+                break
+
+    def mutator():
+        deadline = time.monotonic() + DURATION
+        i = 0
+        while i < ITERATIONS * 4 and time.monotonic() < deadline:
+            key = f"k{i % 64}"
+            try:
+                if i & 1:
+                    target[key] = [i, i + 1, {"x": i}]
+                else:
+                    target.pop(key, None)
+            except Exception:
+                pass
+            i += 1
+
+    # One mutator, rest readers.
+    reader_count = max(THREADS - 1, 1)
+    run_scenario(
+        "mutator vs readers on shared dict",
+        [reader, mutator],
+        [reader_count, 1],
+    )
+
+
+def scenario_module_functions():
+    """Concurrent scanstring + encode_basestring_ascii (module-level)."""
+    scanstring = _speedups.scanstring
+    enc_ascii = _speedups.encode_basestring_ascii
+
+    strings_to_encode = [
+        "hello world",
+        "\"quoted\" with \\ backslash",
+        "\u00e9\u00e8\u00ea \u4e2d\u6587 emoji-\U0001F600",
+        "control\n\t\r chars",
+        "x" * 256,
+    ]
+    # For scanstring: the opening quote has been consumed; pass end=1.
+    scan_sources = [
+        r'"a simple string"',
+        r'"with \"escapes\" and \n newlines"',
+        r'"unicode \u00e9\u00e8\u4e2d\u6587 stuff"',
+        r'"backslashes \\ and slashes \/"',
+    ]
+
+    def enc_worker():
+        deadline = time.monotonic() + DURATION
+        for i in range(ITERATIONS):
+            try:
+                enc_ascii(strings_to_encode[i % len(strings_to_encode)])
+            except Exception:
+                pass
+            if time.monotonic() > deadline:
+                break
+
+    def scan_worker():
+        deadline = time.monotonic() + DURATION
+        for i in range(ITERATIONS):
+            src = scan_sources[i % len(scan_sources)]
+            try:
+                # scanstring(basestring, end, encoding, strict)
+                scanstring(src, 1, "utf-8", 1)
+            except Exception:
+                pass
+            if time.monotonic() > deadline:
+                break
+
+    half = max(THREADS // 2, 1)
+    run_scenario(
+        "module-level scanstring + encode_basestring_ascii",
+        [enc_worker, scan_worker],
+        [half, max(THREADS - half, 1)],
+    )
+
+
+# --------------------------- main ------------------------------------------- #
+
+SCENARIOS = [
+    scenario_shared_scanner,
+    scenario_shared_encoder_distinct_inputs,
+    scenario_shared_encoder_shared_dict,
+    scenario_shared_encoder_shared_list,
+    scenario_mutator_vs_readers,
+    scenario_module_functions,
+]
+
+
+def main():
+    print("TSan stress test for simplejson._speedups")
+    print(f"  Python:       {sys.version.splitlines()[0]}")
+    print(f"  TSan build:   {_is_tsan_build()}")
+    print(f"  PYTHON_GIL:   {os.environ.get('PYTHON_GIL', '<unset>')}")
+    print(f"  Threads:      {THREADS}")
+    print(f"  Iterations:   {ITERATIONS}")
+    print(f"  Duration:     {DURATION}s per scenario")
+    print(f"  Timeout:      {SCENARIO_TIMEOUT}s per scenario")
+    print()
+
+    for sc in SCENARIOS:
+        sc()
+
+    print("\nDone. Inspect stderr (e.g. tsan_report.txt) for TSan warnings.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three encoder correctness/parity fixes and a new TSan CI job. All changes are also reflected in CHANGES.txt.

## `_call_json_method` exception propagation

`for_json()` and `_asdict()` silently swallowed `MemoryError`, `KeyboardInterrupt`, and any other non-`AttributeError` exception raised by a user `__getattr__`, replacing it with a generic `TypeError`. Same bug class as #357 (`iterable_as_array`). The helper now gates `PyErr_Clear()` on `PyErr_ExceptionMatches(PyExc_AttributeError)` and propagates other exceptions via `*result = NULL` so the caller bails through `encoder_steal_encode`.

Regression test: `test_for_json.py::TestForJson::test_getattr_exception_propagates`.

## Python encoder `_asdict` dispatch parity

The Python encoder checked `isinstance(o, list)` before `_asdict()`, so a `list`/`tuple`/`dict` subclass with an `_asdict()` method encoded as its container type under Python but as the `_asdict()` return value under C. Consolidated on C's order (`_asdict()` before `list`/`tuple`/`dict`) because more users have the C extension installed. `for_json()` continues to outrank `_asdict()` in both backends.

Regression test: `test_namedtuple.py::TestNamedTuple::test_asdict_dispatch_order`.

## TSan stress test CI job

New `test_tsan` job builds a TSan-instrumented free-threaded CPython (cached between runs, ~15 min on cache miss, much faster on hit) and runs `tsan_stress_simplejson.py` against the C extension to catch data races under free-threading. Wired into the `gate_ubuntu` aggregate gate so regressions block merges.

## Test plan

- [x] Full suite (219 tests × 2 backends = 438) passes on 3.13 and 3.14 via `python -c "from simplejson.tests import main; main(project_dir='.')"`
- [x] New regression tests fail on pre-fix code and pass after the fix
- [x] `test_tsan` CI job runs green on this PR