### PR TITLE
Exclude Pyodide wheels from PyPI uploads

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -403,6 +403,11 @@ jobs:
           merge-multiple: true
           path: dist
 
+      # PyPI rejects Pyodide/wasm wheels (unsupported platform tag). Drop them
+      # from the upload set; they're still kept as workflow artifacts.
+      - name: Remove Pyodide wheels before upload
+        run: rm -f dist/*pyodide*.whl
+
       - uses: pypa/gh-action-pypi-publish@release/v1
 
   upload_pypi_test:
@@ -422,6 +427,11 @@ jobs:
         with:
           merge-multiple: true
           path: dist
+
+      # PyPI rejects Pyodide/wasm wheels (unsupported platform tag). Drop them
+      # from the upload set; they're still kept as workflow artifacts.
+      - name: Remove Pyodide wheels before upload
+        run: rm -f dist/*pyodide*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+Version 4.0.1 released 2026-04-18
+
+* Skip uploading Pyodide/wasm wheels to PyPI, which rejects them with
+  "unsupported platform tag 'pyodide_2024_0_wasm32'". The wheels are
+  still built in CI and preserved as workflow artifacts.
+  https://github.com/simplejson/simplejson/pull/375
+
 Version 4.0.0 released 2026-04-18
 
 * simplejson 4 requires Python 2.7 or Python 3.8+. Older Python

--- a/conf.py
+++ b/conf.py
@@ -42,9 +42,9 @@ copyright = '2025, Bob Ippolito'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '3.20'
+version = '4.0'
 # The full version, including alpha/beta/rc tags.
-release = '3.20.2'
+release = '4.0.1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
 
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
 IS_GRAALPY = getattr(getattr(sys, "implementation", None), "name", None) == "graalpy"
-VERSION = '4.0.0'
+VERSION = '4.0.1'
 DESCRIPTION = "Simple, fast, extensible JSON encoder/decoder for Python"
 
 with open('README.rst', 'r') as f:

--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -118,7 +118,7 @@ Serializing multiple objects to JSON lines (newline-delimited JSON)::
 
 """
 from __future__ import absolute_import
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 __all__ = [
     'dump', 'dumps', 'load', 'loads',
     'JSONDecoder', 'JSONDecodeError', 'JSONEncoder',


### PR DESCRIPTION
## Summary
This change prevents Pyodide/WebAssembly wheels from being uploaded to PyPI, as they use an unsupported platform tag that PyPI rejects. The wheels are still preserved as workflow artifacts for other purposes.

## Changes
- Added a step to remove `*pyodide*.whl` files before uploading to PyPI in the `upload_pypi` job
- Added the same step to the `upload_pypi_test` job for consistency

## Implementation Details
- The removal is done via `rm -f dist/*pyodide*.whl` immediately before the PyPI publish action
- This approach filters out incompatible wheels while keeping them available as GitHub workflow artifacts
- The same pattern is applied to both production and test PyPI upload workflows to ensure consistent behavior

https://claude.ai/code/session_01EobRBPCKqFGf5dZQ7NRAup