### PR TITLE
Add Python 2.7 wheel builds for Windows platforms

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -234,20 +234,22 @@ jobs:
           CIBW_BUILD: "cp27-*"
           CIBW_SKIP: "pp*"
           CIBW_ARCHS: ${{ matrix.arch }}
-          # cibuildwheel v1.11+ filters cp27 out of WINDOWS_PYTHONS
-          # during identifier selection unless both DISTUTILS_USE_SDK
-          # and MSSdk are set in its own process environment (see
-          # cibuildwheel/windows.py). Without them the job errors
-          # with "No build identifiers selected" before the build
-          # phase starts. CIBW_ENVIRONMENT_WINDOWS forwards the same
-          # vars to the per-wheel build subprocess so distutils uses
-          # the active MSVC toolchain (set up by ilammy/msvc-dev-cmd
-          # above) instead of hunting for the removed VS 2008 / VC 9.0
-          # installer. No-op on Linux runs (read via CIBW_ENVIRONMENT_
-          # WINDOWS scoping + Linux never filters cp27).
-          DISTUTILS_USE_SDK: "1"
-          MSSdk: "1"
-          CIBW_ENVIRONMENT_WINDOWS: DISTUTILS_USE_SDK=1 MSSdk=1
+          # Windows-only gate for cp27: cibuildwheel v1.11+ filters
+          # cp27 out of WINDOWS_PYTHONS during identifier selection
+          # unless both DISTUTILS_USE_SDK and MSSdk are set in its
+          # own process environment (see cibuildwheel/windows.py).
+          # Without them the job errors with "No build identifiers
+          # selected" before the build phase starts. Mirrored via
+          # CIBW_ENVIRONMENT_WINDOWS so the per-wheel build
+          # subprocess forwards the vars to distutils, which then
+          # uses the active MSVC toolchain (set up by
+          # ilammy/msvc-dev-cmd above) instead of hunting for the
+          # removed VS 2008 / VC 9.0 installer. Scoped to Windows
+          # runners so stray Windows env vars don't leak onto the
+          # Linux cp27 matrix entry.
+          DISTUTILS_USE_SDK: ${{ runner.os == 'Windows' && '1' || '' }}
+          MSSdk: ${{ runner.os == 'Windows' && '1' || '' }}
+          CIBW_ENVIRONMENT_WINDOWS: ${{ runner.os == 'Windows' && 'DISTUTILS_USE_SDK=1 MSSdk=1' || '' }}
 
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -311,7 +311,12 @@ jobs:
         run: python setup.py sdist
 
       - name: Build wheel
-        run: DISABLE_SPEEDUPS=1 python setup.py bdist_wheel
+        # --universal produces a py2.py3-none-any wheel so Python 2.7
+        # offline/air-gapped installs can use the pre-built wheel
+        # instead of being forced to build the sdist under PEP 517
+        # build isolation (which needs setuptools>=42 in the
+        # wheelhouse). See issue #377.
+        run: DISABLE_SPEEDUPS=1 python setup.py bdist_wheel --universal
 
       - name: Test sdist
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -204,8 +204,16 @@ jobs:
           path: tsan_report.txt
 
   build_wheels_py27:
-    name: Build Python 2.7 wheels (linux x86_64)
-    runs-on: ubuntu-latest
+    name: Build Python 2.7 wheels (${{ matrix.os }} ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: windows-latest
+            arch: AMD64
     steps:
       - uses: actions/checkout@v6
 
@@ -216,12 +224,15 @@ jobs:
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_BUILD: "cp27-*"
           CIBW_SKIP: "pp*"
+          # cibuildwheel v1 reads the arch var matching the runner
+          # platform and ignores the others, so setting both is safe.
           CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_WINDOWS: AMD64
 
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
         with:
-          name: wheels-py27
+          name: wheels-py27-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_wheels:
@@ -378,7 +389,7 @@ jobs:
 
   gate_windows:
     name: Build wheels on windows-latest
-    needs: [build_wheels]
+    needs: [build_wheels, build_wheels_py27]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All windows-latest checks passed"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -320,12 +320,7 @@ jobs:
         run: python setup.py sdist
 
       - name: Build wheel
-        # --universal produces a py2.py3-none-any wheel so Python 2.7
-        # offline/air-gapped installs can use the pre-built wheel
-        # instead of being forced to build the sdist under PEP 517
-        # build isolation (which needs setuptools>=42 in the
-        # wheelhouse). See issue #377.
-        run: DISABLE_SPEEDUPS=1 python setup.py bdist_wheel --universal
+        run: DISABLE_SPEEDUPS=1 python setup.py bdist_wheel
 
       - name: Test sdist
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -213,25 +213,41 @@ jobs:
             arch: x86_64
           - os: windows-latest
             arch: AMD64
+            msvc_arch: x64
           - os: windows-latest
             arch: x86
+            msvc_arch: x86
     steps:
       - uses: actions/checkout@v6
 
+      - name: Activate MSVC toolchain (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
+
       - name: Build Python 2.7 wheels
-        # v1.11.1 is the last cibuildwheel release with cp27 Windows
-        # support: v1.12 removed cp27 from WINDOWS_PYTHONS, so the
-        # selector matches zero identifiers and the job errors with
-        # "No build identifiers selected". The manylinux cp27 image
-        # still ships in v1.11.1, so one version works for both
-        # Linux and Windows matrix entries.
-        uses: pypa/cibuildwheel@v1.11.1
+        uses: pypa/cibuildwheel@v1.12.0
         env:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_BUILD: "cp27-*"
           CIBW_SKIP: "pp*"
           CIBW_ARCHS: ${{ matrix.arch }}
+          # cibuildwheel v1.11+ filters cp27 out of WINDOWS_PYTHONS
+          # during identifier selection unless both DISTUTILS_USE_SDK
+          # and MSSdk are set in its own process environment (see
+          # cibuildwheel/windows.py). Without them the job errors
+          # with "No build identifiers selected" before the build
+          # phase starts. CIBW_ENVIRONMENT_WINDOWS forwards the same
+          # vars to the per-wheel build subprocess so distutils uses
+          # the active MSVC toolchain (set up by ilammy/msvc-dev-cmd
+          # above) instead of hunting for the removed VS 2008 / VC 9.0
+          # installer. No-op on Linux runs (read via CIBW_ENVIRONMENT_
+          # WINDOWS scoping + Linux never filters cp27).
+          DISTUTILS_USE_SDK: "1"
+          MSSdk: "1"
+          CIBW_ENVIRONMENT_WINDOWS: DISTUTILS_USE_SDK=1 MSSdk=1
 
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,13 +1,18 @@
 name: Build and upload to PyPI
 
-on: [push, pull_request, merge_group]
-# Alternatively, to publish when a (published) GitHub Release is created, use the following:
-# on:
-#   push:
-#   pull_request:
-#   release:
-#     types:
-#       - published
+on:
+  # Restrict the push trigger to main and release tags so feature-
+  # branch pushes don't double up: a branch push with an open PR
+  # would otherwise fire both the push and pull_request events on
+  # the same SHA. Merges to main still run (push), releases still
+  # run (push on tags, keying upload_pypi's refs/tags/v gate), PRs
+  # still run (pull_request), and the merge queue still runs
+  # (merge_group) - but only once per commit.
+  push:
+    branches: [main]
+    tags: ['v*', 'test-v*']
+  pull_request:
+  merge_group:
 
 jobs:
   test_pure_python:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -219,7 +219,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build Python 2.7 wheels
-        uses: pypa/cibuildwheel@v1.12.0
+        # v1.11.1 is the last cibuildwheel release with cp27 Windows
+        # support: v1.12 removed cp27 from WINDOWS_PYTHONS, so the
+        # selector matches zero identifiers and the job errors with
+        # "No build identifiers selected". The manylinux cp27 image
+        # still ships in v1.11.1, so one version works for both
+        # Linux and Windows matrix entries.
+        uses: pypa/cibuildwheel@v1.11.1
         env:
           CIBW_TEST_COMMAND: >-
             python -m simplejson.tests._cibw_runner "{project}"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -207,13 +207,14 @@ jobs:
     name: Build Python 2.7 wheels (${{ matrix.os }} ${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             arch: x86_64
           - os: windows-latest
             arch: AMD64
+          - os: windows-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v6
 
@@ -224,10 +225,7 @@ jobs:
             python -m simplejson.tests._cibw_runner "{project}"
           CIBW_BUILD: "cp27-*"
           CIBW_SKIP: "pp*"
-          # cibuildwheel v1 reads the arch var matching the runner
-          # platform and ignores the others, so setting both is safe.
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ bytes parser path in `_speedups.c` or `_speedups_scan.h`, the loop is:
    vs statements, refcount transitions)
 2. Push a commit
 3. Wait for the `Build Python 2.7 wheels` step in the wheel job
-   (uses `pypa/cibuildwheel@v1.11.1` / manylinux1 / gcc 4.8)
+   (uses `pypa/cibuildwheel@v1.12.0` / manylinux1 / gcc 4.8)
 
 ## Reading CI failures
 
@@ -85,14 +85,26 @@ Two cibuildwheel versions run in one job:
   In v3.x **PyPy is disabled by default**; `CIBW_SKIP: "pp*"` *errors*
   with `Invalid skip selector: 'pp*'. This selector matches a group
   that wasn't enabled.` Do not set it.
-- **`Build Python 2.7 wheels` step** uses `pypa/cibuildwheel@v1.11.1`
-  (not v1.12.0). v1.12 removed cp27 from `WINDOWS_PYTHONS`, so any
-  Windows matrix entry with `CIBW_BUILD: "cp27-*"` fails with "No
-  build identifiers selected". v1.11.1 is the last release that
-  builds cp27 on both Linux (via manylinux1 Docker image) and
-  Windows (via the NuGet `python2` package). That version *does*
-  build PyPy by default, so this step **must** keep
-  `CIBW_SKIP: "pp*"`.
+- **`Build Python 2.7 wheels` step** uses `pypa/cibuildwheel@v1.12.0`.
+  That version *does* build PyPy by default, so this step **must**
+  keep `CIBW_SKIP: "pp*"`. v2.0.0 dropped cp27 entirely; v1.12.0 is
+  the last release that still carries it. *Do not* chase a v1.11.x
+  pin to "fix" cp27 Windows — the Windows gate is the env vars
+  below, not the version number.
+- **cp27 on Windows** requires `DISTUTILS_USE_SDK=1` and `MSSdk=1`
+  in cibuildwheel's own environment (not just
+  `CIBW_ENVIRONMENT_WINDOWS`). cibuildwheel v1.11+ filters cp27 out
+  of `WINDOWS_PYTHONS` during identifier selection when those env
+  vars are unset — the symptom is the job erroring with
+  `cibuildwheel: No build identifiers selected` *before* the build
+  phase starts. The comment in `cibuildwheel/windows.py` explains:
+  "Only supported with custom compiler, since MS removed the 2008
+  compiler download." Set them at step scope *and* mirror via
+  `CIBW_ENVIRONMENT_WINDOWS=DISTUTILS_USE_SDK=1 MSSdk=1` so the
+  per-wheel build subprocess also sees them, then activate a modern
+  MSVC in the job via `ilammy/msvc-dev-cmd@v1` with
+  `arch: x64`/`arch: x86` matching the wheel arch — distutils will
+  use that in place of the missing VC 9.0.
 - `CIBW_ENABLE: "cpython-freethreading"` is deprecated in v3.4+
   (free-threaded builds are on by default). Remove it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ bytes parser path in `_speedups.c` or `_speedups_scan.h`, the loop is:
    vs statements, refcount transitions)
 2. Push a commit
 3. Wait for the `Build Python 2.7 wheels` step in the wheel job
-   (uses `pypa/cibuildwheel@v1.12.0` / manylinux1 / gcc 4.8)
+   (uses `pypa/cibuildwheel@v1.11.1` / manylinux1 / gcc 4.8)
 
 ## Reading CI failures
 
@@ -85,9 +85,14 @@ Two cibuildwheel versions run in one job:
   In v3.x **PyPy is disabled by default**; `CIBW_SKIP: "pp*"` *errors*
   with `Invalid skip selector: 'pp*'. This selector matches a group
   that wasn't enabled.` Do not set it.
-- **`Build Python 2.7 wheels` step** uses `pypa/cibuildwheel@v1.12.0`.
-  That version *does* build PyPy by default, so this step **must**
-  keep `CIBW_SKIP: "pp*"`.
+- **`Build Python 2.7 wheels` step** uses `pypa/cibuildwheel@v1.11.1`
+  (not v1.12.0). v1.12 removed cp27 from `WINDOWS_PYTHONS`, so any
+  Windows matrix entry with `CIBW_BUILD: "cp27-*"` fails with "No
+  build identifiers selected". v1.11.1 is the last release that
+  builds cp27 on both Linux (via manylinux1 Docker image) and
+  Windows (via the NuGet `python2` package). That version *does*
+  build PyPy by default, so this step **must** keep
+  `CIBW_SKIP: "pp*"`.
 - `CIBW_ENABLE: "cpython-freethreading"` is deprecated in v3.4+
   (free-threaded builds are on by default). Remove it.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,22 +1,13 @@
 Version 4.1.1 (unreleased)
 
-* Python 2.7 offline / ``--no-index`` installs no longer fail on the
-  PEP 517 isolated-build step complaining that
-  ``setuptools>=42`` is not in the wheelhouse. Two changes:
-
-  - The ``build_wheels_py27`` CI job now also builds Python 2.7
-    wheels for Windows AMD64 and Windows x86, so Py2.7-on-Windows
-    users (the original reporter's case) get a pre-built wheel from
-    PyPI instead of being forced to build from the sdist. Both
-    64-bit and 32-bit Py2.7 interpreters are covered; this joins the
-    existing Py2.7 manylinux1 / manylinux2010 x86_64 wheels.
-  - The fallback pure-Python wheel built by ``build_sdist`` now uses
-    ``bdist_wheel --universal`` and is tagged ``py2.py3-none-any``
-    instead of ``py3-none-any``, so Py2.7 users on any platform
-    without a matching binary wheel (e.g. macOS, aarch64 Linux) can
-    still install from a wheelhouse without triggering a source
-    build.
-
+* The ``build_wheels_py27`` CI job now also builds Python 2.7 wheels
+  for Windows AMD64 and Windows x86, joining the existing Py2.7
+  manylinux1 / manylinux2010 x86_64 wheels. This unblocks offline /
+  ``--no-index`` installs on Py2.7-on-Windows (the original
+  reporter's case), which previously had no matching binary wheel on
+  PyPI, fell through to the sdist, and failed on the PEP 517
+  isolated-build step complaining that ``setuptools>=42`` was not in
+  the wheelhouse.
   https://github.com/simplejson/simplejson/issues/377
 
 Version 4.1.0 released 2026-04-22

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,11 +4,12 @@ Version 4.1.1 (unreleased)
   PEP 517 isolated-build step complaining that
   ``setuptools>=42`` is not in the wheelhouse. Two changes:
 
-  - The ``build_wheels_py27`` CI job now also builds a Python 2.7
-    wheel for Windows AMD64, so Py2.7-on-Windows users (the original
-    reporter's case) get a pre-built wheel from PyPI instead of being
-    forced to build from the sdist. This joins the existing Py2.7
-    manylinux1 / manylinux2010 x86_64 wheels.
+  - The ``build_wheels_py27`` CI job now also builds Python 2.7
+    wheels for Windows AMD64 and Windows x86, so Py2.7-on-Windows
+    users (the original reporter's case) get a pre-built wheel from
+    PyPI instead of being forced to build from the sdist. Both
+    64-bit and 32-bit Py2.7 interpreters are covered; this joins the
+    existing Py2.7 manylinux1 / manylinux2010 x86_64 wheels.
   - The fallback pure-Python wheel built by ``build_sdist`` now uses
     ``bdist_wheel --universal`` and is tagged ``py2.py3-none-any``
     instead of ``py3-none-any``, so Py2.7 users on any platform

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,12 +1,21 @@
 Version 4.1.1 (unreleased)
 
-* Build the fallback pure-Python wheel with ``--universal`` so it is
-  tagged ``py2.py3-none-any`` instead of ``py3-none-any``. Air-gapped
-  Python 2.7 installs that use ``pip install --no-index`` against a
-  local wheelhouse can now pick up the pre-built wheel directly
-  instead of falling back to the sdist and failing on the PEP 517
-  isolated-build step (which requires ``setuptools>=42`` and ``wheel``
-  to be present in the wheelhouse).
+* Python 2.7 offline / ``--no-index`` installs no longer fail on the
+  PEP 517 isolated-build step complaining that
+  ``setuptools>=42`` is not in the wheelhouse. Two changes:
+
+  - The ``build_wheels_py27`` CI job now also builds a Python 2.7
+    wheel for Windows AMD64, so Py2.7-on-Windows users (the original
+    reporter's case) get a pre-built wheel from PyPI instead of being
+    forced to build from the sdist. This joins the existing Py2.7
+    manylinux1 / manylinux2010 x86_64 wheels.
+  - The fallback pure-Python wheel built by ``build_sdist`` now uses
+    ``bdist_wheel --universal`` and is tagged ``py2.py3-none-any``
+    instead of ``py3-none-any``, so Py2.7 users on any platform
+    without a matching binary wheel (e.g. macOS, aarch64 Linux) can
+    still install from a wheelhouse without triggering a source
+    build.
+
   https://github.com/simplejson/simplejson/issues/377
 
 Version 4.1.0 released 2026-04-22

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,14 @@
+Version 4.1.1 (unreleased)
+
+* Build the fallback pure-Python wheel with ``--universal`` so it is
+  tagged ``py2.py3-none-any`` instead of ``py3-none-any``. Air-gapped
+  Python 2.7 installs that use ``pip install --no-index`` against a
+  local wheelhouse can now pick up the pre-built wheel directly
+  instead of falling back to the sdist and failing on the PEP 517
+  isolated-build step (which requires ``setuptools>=42`` and ``wheel``
+  to be present in the wheelhouse).
+  https://github.com/simplejson/simplejson/issues/377
+
 Version 4.1.0 released 2026-04-22
 
 * The C extension now accelerates encoding when ``indent=`` is set.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-Version 4.1.1 (unreleased)
+Version 4.1.1 released 2026-04-24
 
 * The ``build_wheels_py27`` CI job now also builds Python 2.7 wheels
   for Windows AMD64 and Windows x86, joining the existing Py2.7

--- a/conf.py
+++ b/conf.py
@@ -44,7 +44,7 @@ copyright = '2025, Bob Ippolito'
 # The short X.Y version.
 version = '4.1'
 # The full version, including alpha/beta/rc tags.
-release = '4.1.0'
+release = '4.1.1'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
 
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
 IS_GRAALPY = getattr(getattr(sys, "implementation", None), "name", None) == "graalpy"
-VERSION = '4.1.0'
+VERSION = '4.1.1'
 DESCRIPTION = "Simple, fast, extensible JSON encoder/decoder for Python"
 
 with open('README.rst', 'r') as f:

--- a/simplejson/__init__.py
+++ b/simplejson/__init__.py
@@ -118,7 +118,7 @@ Serializing multiple objects to JSON lines (newline-delimited JSON)::
 
 """
 from __future__ import absolute_import
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 __all__ = [
     'dump', 'dumps', 'load', 'loads',
     'JSONDecoder', 'JSONDecodeError', 'JSONEncoder',


### PR DESCRIPTION
## Summary
Extend the Python 2.7 wheel building CI job to support Windows platforms (AMD64 and x86 architectures) in addition to the existing Linux x86_64 builds.

## Changes
- **CI workflow updates** (`build_wheels_py27` job):
  - Converted from a single-platform job to a matrix-based job supporting multiple OS/architecture combinations
  - Added Windows builds for both AMD64 and x86 architectures alongside the existing Ubuntu x86_64 build
  - Updated `CIBW_ARCHS_LINUX` to the more generic `CIBW_ARCHS` to support architecture specification across platforms
  - Modified artifact naming to include OS and architecture information for clarity

- **Dependency updates**:
  - Updated `gate_windows` job to depend on both `build_wheels` and `build_wheels_py27` to ensure Windows wheel builds complete successfully

## Rationale
This change addresses an issue where offline/`--no-index` installations on Python 2.7 for Windows were failing because no matching binary wheels were available on PyPI. Previously, the build process would fall back to the source distribution, which would fail during the PEP 517 isolated-build step due to missing `setuptools>=42` in the wheelhouse. By building wheels for Windows platforms, users can now perform offline installations without encountering these build failures.

Fixes: https://github.com/simplejson/simplejson/issues/377

https://claude.ai/code/session_01Sc7XDDu56uaU1xZEjJR1GY