### PR TITLE
Fix control character error position when content precedes the control char

### DIFF
--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -102,7 +102,7 @@ def py_scanstring(s, end, encoding=None, strict=True,
         elif terminator != '\\':
             if strict:
                 msg = "Invalid control character %r at"
-                raise JSONDecodeError(msg, s, prev_end)
+                raise JSONDecodeError(msg, s, end - 1)
             else:
                 _append(terminator)
                 continue

--- a/simplejson/tests/test_fail.py
+++ b/simplejson/tests/test_fail.py
@@ -158,6 +158,8 @@ class TestFail(TestCase):
             ('[,', "Expecting value", 1),
             ('--', 'Expecting value', 0),
             ('"\x18d', "Invalid control character %r", 1),
+            # control char after content: pos must point to the control char, not start of content
+            ('"d\x18"', "Invalid control character %r", 2),
         ]
         for data, msg, idx in test_cases:
             try:


### PR DESCRIPTION
## Bug

When `py_scanstring` raises `JSONDecodeError` for a literal control character inside a string, it reported the wrong position and the wrong character in the error message whenever there was content before the control character.

**Example:**

```python
>>> import simplejson
>>> simplejson.loads('"d\x18"')
# Before fix:
# JSONDecodeError: Invalid control character 'd' at: line 1 column 2 (char 1)
#  - reports 'd' (content start) instead of '\x18' (the control char)
#  - pos=1 instead of pos=2

# After fix:
# JSONDecodeError: Invalid control character '\x18' at: line 1 column 3 (char 2)
#  - correct character, correct position (matches stdlib json)
```

The stdlib `json` module correctly reports `pos=2` for the same input.

## Root cause

In `py_scanstring`, after the regex match the variable `prev_end` holds the *start* of the scanned content chunk, not the position of the terminator. The control character is always at `end - 1` (one before `chunk.end()`).

**Fix:** Use `end - 1` instead of `prev_end` when raising the error.

## Changes

- `simplejson/decoder.py`: use `end - 1` (the regex terminator position) rather than `prev_end` (content start) for the error location
- `simplejson/tests/test_fail.py`: add regression test for a control character preceded by normal content