### PR TITLE
Report the offending char, not the backslash, for invalid \X escapes

### DIFF
--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -1365,7 +1365,7 @@ scanstring_str(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 2);
+                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 1);
                 goto bail;
             }
         }
@@ -1564,7 +1564,7 @@ scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 2);
+                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 1);
                 goto bail;
             }
         }
@@ -1755,7 +1755,7 @@ scanstring_unicode(_speedups_state *state, PyObject *pystr, Py_ssize_t end,
                 default: c = 0;
             }
             if (c == 0) {
-                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 2);
+                raise_errmsg(state, ERR_STRING_ESC1, pystr, end - 1);
                 goto bail;
             }
         }

--- a/simplejson/tests/test_scanstring.py
+++ b/simplejson/tests/test_scanstring.py
@@ -290,3 +290,49 @@ class TestScanString(TestCase):
             self.assertEqual(
                 scanstring(u'\\ud834\\udd1e"', 0, None, True),
                 (u'\U0001d11e', 13))
+
+    def test_single_char_escape_error_parity(self):
+        # Regression: for an invalid single-character escape (``\X``), the C
+        # scanstring reported the position of the backslash, while
+        # py_scanstring reports the position of the offending escape
+        # character itself. Because the "Invalid \\X escape sequence %r"
+        # message renders %r as the character at that position, the C path
+        # produced the nonsensical "Invalid \\X escape sequence '\\'" (naming
+        # the backslash, which is always a valid escape introducer) instead
+        # of naming the actual bad character. This asserts exact parity
+        # (position and rendered message) between the two backends, matching
+        # the \\uXXXX parity already covered by test_escape_error_parity.
+        if simplejson.decoder.c_scanstring is None:
+            return
+
+        def get_exc(scanstring, s):
+            try:
+                scanstring(s, 0, None, True)
+            except json.JSONDecodeError as e:
+                return (e.pos, str(e).split(': line ')[0])
+            return None
+
+        # Each case: (input, escape_char_index). The rendered message must
+        # name the character at escape_char_index, never the backslash.
+        cases = [
+            (u'\\x41"', 1),
+            (u'a\\q"', 2),
+            (u'\\ "', 1),
+            (u'prefix\\z"', 7),
+            (u'\\!"', 1),
+        ]
+        for s, esc_idx in cases:
+            expected = (
+                esc_idx,
+                "Invalid \\X escape sequence %r" % (s[esc_idx],))
+            py = get_exc(simplejson.decoder.py_scanstring, s)
+            c = get_exc(simplejson.decoder.c_scanstring, s)
+            self.assertEqual(py, expected,
+                             'py_scanstring(%r) expected %r, got %r' %
+                             (s, expected, py))
+            self.assertEqual(c, expected,
+                             'c_scanstring(%r) expected %r, got %r' %
+                             (s, expected, c))
+            # The reported position must land on the bad char, not the '\\'.
+            self.assertNotEqual(s[c[0]], u'\\',
+                                'c_scanstring(%r) pointed at the backslash' % (s,))


### PR DESCRIPTION
### Problem

For an invalid single-character escape (`\X`), the C `scanstring` reports the
position of the **backslash** and renders the wrong character in the message,
while the pure-Python `py_scanstring` reports the offending escape character:

```python
>>> import simplejson
>>> simplejson.loads('"\\x41"')
# C path:      Invalid \X escape sequence '\' : line 1 column 1 (char 0)
# Python path: Invalid \X escape sequence 'x' : line 1 column 2 (char 1)
```

`ERR_STRING_ESC1` renders `%r` of the character *at the reported position*, so
passing `end - 2` names `'\'` — the backslash, which is always a valid escape
introducer — and points at the wrong column. This is actively misleading when
debugging malformed JSON through the C-accelerated path.

### Cause

`simplejson/_speedups.c` passes `end - 2` (the backslash) instead of `end - 1`
(the escape character) to `raise_errmsg(state, ERR_STRING_ESC1, ...)` in all
three scanstring branches (`scanstring_str` and both `scanstring_unicode`
includes).

### Fix

Pass `end - 1` in the three branches so the C extension names the actual
offending character and reports the same position as the pure-Python reference.
This mirrors the control-character position fix in #379.

### Tests

`test_single_char_escape_error_parity` asserts exact `(position, message)`
parity between `c_scanstring` and `py_scanstring` across five invalid-escape
inputs, and that the reported position never lands on the backslash. It mirrors
the existing `test_escape_error_parity` (which covers the `\uXXXX` branch).

Full test suite (C-speedups path and pure-Python path): 190 passed, 30 skipped,
0 regressions.
