### PR TITLE
Handle non-finite Decimals like floats in the encoder (fixes #149)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+Version 4.1.2 (unreleased)
+
+* Non-finite ``Decimal`` values are now handled consistently with the
+  matching ``float``.  Previously ``NaN``, ``sNaN`` and ``Infinity``
+  ``Decimal`` values bypassed the ``allow_nan`` / ``ignore_nan``
+  handling: ``ignore_nan=True`` emitted a literal ``NaN`` instead of
+  ``null``, and ``allow_nan=False`` silently emitted the invalid JSON
+  literal instead of raising ``ValueError``.  Finite ``Decimal`` values
+  (including ``0.00`` and other trailing-zero forms) are unchanged.  The
+  fix is applied to both the pure-Python encoder and the C extension.
+  https://github.com/simplejson/simplejson/issues/149
+
 Version 4.1.1 released 2026-04-24
 
 * The ``build_wheels_py27`` CI job now also builds Python 2.7 wheels

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,15 +1,3 @@
-Version 4.1.2 (unreleased)
-
-* Non-finite ``Decimal`` values are now handled consistently with the
-  matching ``float``.  Previously ``NaN``, ``sNaN`` and ``Infinity``
-  ``Decimal`` values bypassed the ``allow_nan`` / ``ignore_nan``
-  handling: ``ignore_nan=True`` emitted a literal ``NaN`` instead of
-  ``null``, and ``allow_nan=False`` silently emitted the invalid JSON
-  literal instead of raising ``ValueError``.  Finite ``Decimal`` values
-  (including ``0.00`` and other trailing-zero forms) are unchanged.  The
-  fix is applied to both the pure-Python encoder and the C extension.
-  https://github.com/simplejson/simplejson/issues/149
-
 Version 4.1.1 released 2026-04-24
 
 * The ``build_wheels_py27`` CI job now also builds Python 2.7 wheels

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2788,32 +2788,37 @@ _encoded_const(_speedups_state *state, PyObject *obj)
 }
 
 static PyObject *
+encoder_encode_nonfinite(PyEncoderObject *s, int sign)
+{
+    _speedups_state *state = get_speedups_state(s->module_ref);
+
+    if (!s->allow_or_ignore_nan) {
+        PyErr_SetString(PyExc_ValueError, "Out of range float values are not JSON compliant");
+        return NULL;
+    }
+    if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
+        return _encoded_const(state, Py_None);
+    }
+    /* JSON_ALLOW_NAN is set */
+    if (sign > 0) {
+        Py_INCREF(state->JSON_Infinity);
+        return state->JSON_Infinity;
+    }
+    if (sign < 0) {
+        Py_INCREF(state->JSON_NegInfinity);
+        return state->JSON_NegInfinity;
+    }
+    Py_INCREF(state->JSON_NaN);
+    return state->JSON_NaN;
+}
+
+static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a PyFloat */
-    _speedups_state *state = get_speedups_state(s->module_ref);
     double i = PyFloat_AS_DOUBLE(obj);
     if (!Py_IS_FINITE(i)) {
-        if (!s->allow_or_ignore_nan) {
-            PyErr_SetString(PyExc_ValueError, "Out of range float values are not JSON compliant");
-            return NULL;
-        }
-        if (s->allow_or_ignore_nan & JSON_IGNORE_NAN) {
-            return _encoded_const(state, Py_None);
-        }
-        /* JSON_ALLOW_NAN is set */
-        else if (i > 0) {
-            Py_INCREF(state->JSON_Infinity);
-            return state->JSON_Infinity;
-        }
-        else if (i < 0) {
-            Py_INCREF(state->JSON_NegInfinity);
-            return state->JSON_NegInfinity;
-        }
-        else {
-            Py_INCREF(state->JSON_NaN);
-            return state->JSON_NaN;
-        }
+        return encoder_encode_nonfinite(s, i > 0 ? 1 : (i < 0 ? -1 : 0));
     }
     /* Use a better float format here? */
     if (PyFloat_CheckExact(obj)) {
@@ -2846,8 +2851,6 @@ encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
        value's is a letter ('N'/'s' for [s]NaN, 'I' for Infinity). So a single
        str() plus a one/two character check distinguishes the two. */
     PyObject *str = PyObject_Str(obj);
-    PyObject *floatobj;
-    PyObject *encoded;
     Py_ssize_t len;
     int negative;
     JSON_UNICHR c;
@@ -2879,27 +2882,14 @@ encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
     if (len > (negative ? 1 : 0))
         c = (unsigned char)data[negative ? 1 : 0];
 #endif
-    if (c <= '9') {
-        /* First significant character is a digit (or unexpectedly empty):
-           finite Decimal, emit as-is. */
+    if (IS_DIGIT(c)) {
+        /* First significant character is a digit: finite Decimal, emit as-is. */
         return str;
     }
-    /* Non-finite Decimal; map to the equivalent float and let
-       encoder_encode_float apply allow_nan/ignore_nan. float(Decimal('sNaN'))
-       raises, so both quiet and signaling NaN ('N'/'s') map to a plain NaN;
-       'I' is an infinity carrying the sign already parsed above. */
+    /* Non-finite Decimal; use the same allow_nan/ignore_nan path as floats
+       without creating a temporary float. */
     Py_DECREF(str);
-    if (c == 'I') {
-        floatobj = PyFloat_FromDouble(negative ? -Py_HUGE_VAL : Py_HUGE_VAL);
-    }
-    else {
-        floatobj = PyFloat_FromDouble(Py_NAN);
-    }
-    if (floatobj == NULL)
-        return NULL;
-    encoded = encoder_encode_float(s, floatobj);
-    Py_DECREF(floatobj);
-    return encoded;
+    return encoder_encode_nonfinite(s, c == 'I' ? (negative ? -1 : 1) : 0);
 }
 
 static PyObject *

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -138,6 +138,8 @@ typedef struct {
     PyObject *JSON_attr_sort;         /* "sort" */
     PyObject *JSON_attr_encoded_json; /* "encoded_json" */
     PyObject *JSON_attr_add_note;     /* "add_note" (PEP 678, 3.11+) */
+    PyObject *JSON_attr_is_finite;    /* "is_finite" (Decimal, see #149) */
+    PyObject *JSON_attr_is_nan;       /* "is_nan" (Decimal, see #149) */
     PyObject *RawJSONType;
     PyObject *JSONDecodeError;
 } _speedups_state;
@@ -429,6 +431,8 @@ static PyObject *
 encoder_long_to_str(PyObject *obj);
 static PyObject *
 encoder_encode_float(PyEncoderObject *s, PyObject *obj);
+static PyObject *
+encoder_encode_decimal(PyEncoderObject *s, PyObject *obj);
 static int
 encoder_accumulate_newline_indent(PyEncoderObject *s, _speedups_state *state,
                                   JSON_Accu *rval, Py_ssize_t indent_level);
@@ -1062,7 +1066,7 @@ encoder_stringify_key(PyEncoderObject *s, PyObject *key)
         return encoder_long_to_str(key);
     }
     else if (s->use_decimal && PyObject_TypeCheck(key, (PyTypeObject *)s->Decimal)) {
-        return PyObject_Str(key);
+        return encoder_encode_decimal(s, key);
     }
     if (s->skipkeys) {
         Py_INCREF(Py_None);
@@ -2830,6 +2834,57 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     }
 }
 
+static int
+decimal_is_true_method(PyObject *obj, PyObject *method_name)
+{
+    /* Call a no-arg predicate method (is_finite/is_nan) on a Decimal and
+       return its truth value, or -1 on error. */
+    PyObject *res = PyObject_CallMethodObjArgs(obj, method_name, NULL);
+    int rv;
+    if (res == NULL)
+        return -1;
+    rv = PyObject_IsTrue(res);
+    Py_DECREF(res);
+    return rv;
+}
+
+static PyObject *
+encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
+{
+    /* Return the JSON representation of a Decimal. Finite Decimals are
+       stringified as-is (preserving precision and trailing zeros); non-finite
+       Decimals (NaN, sNaN, Infinity) are routed through the same
+       allow_nan/ignore_nan handling as floats so they never emit invalid
+       JSON. See https://github.com/simplejson/simplejson/issues/149 */
+    _speedups_state *state = get_speedups_state(s->module_ref);
+    PyObject *floatobj;
+    PyObject *encoded;
+    int is_finite;
+    int is_nan;
+    is_finite = decimal_is_true_method(obj, state->JSON_attr_is_finite);
+    if (is_finite < 0)
+        return NULL;
+    if (is_finite)
+        return PyObject_Str(obj);
+    /* Non-finite: map to the equivalent float. float(Decimal('sNaN'))
+       raises, so signaling (and quiet) NaNs are mapped to a plain NaN;
+       infinities convert cleanly. */
+    is_nan = decimal_is_true_method(obj, state->JSON_attr_is_nan);
+    if (is_nan < 0)
+        return NULL;
+    if (is_nan) {
+        floatobj = PyFloat_FromDouble(Py_NAN);
+    }
+    else {
+        floatobj = PyNumber_Float(obj);
+    }
+    if (floatobj == NULL)
+        return NULL;
+    encoded = encoder_encode_float(s, floatobj);
+    Py_DECREF(floatobj);
+    return encoded;
+}
+
 static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj)
 {
@@ -3090,7 +3145,7 @@ encoder_listencode_obj(PyEncoderObject *s, JSON_Accu *rval, PyObject *obj, Py_ss
         Py_LeaveRecursiveCall();
     }
     else if (s->use_decimal && PyObject_TypeCheck(obj, (PyTypeObject *)s->Decimal)) {
-        PyObject *encoded = PyObject_Str(obj);
+        PyObject *encoded = encoder_encode_decimal(s, obj);
         if (encoded != NULL)
             rv = _steal_accumulate(state, rval, encoded);
     }
@@ -3746,6 +3801,8 @@ reset_speedups_state_constants(_speedups_state *state)
     Py_CLEAR(state->JSON_attr_sort);
     Py_CLEAR(state->JSON_attr_encoded_json);
     Py_CLEAR(state->JSON_attr_add_note);
+    Py_CLEAR(state->JSON_attr_is_finite);
+    Py_CLEAR(state->JSON_attr_is_nan);
     Py_CLEAR(state->RawJSONType);
     Py_CLEAR(state->JSONDecodeError);
 }
@@ -3851,6 +3908,12 @@ init_speedups_state(_speedups_state *state, PyObject *module)
     state->JSON_attr_add_note = JSON_InternFromString("add_note");
     if (state->JSON_attr_add_note == NULL)
         return -1;
+    state->JSON_attr_is_finite = JSON_InternFromString("is_finite");
+    if (state->JSON_attr_is_finite == NULL)
+        return -1;
+    state->JSON_attr_is_nan = JSON_InternFromString("is_nan");
+    if (state->JSON_attr_is_nan == NULL)
+        return -1;
 
     (void)module;
     return 0;
@@ -3938,6 +4001,8 @@ speedups_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(state->JSON_attr_asdict);
     Py_VISIT(state->JSON_attr_sort);
     Py_VISIT(state->JSON_attr_encoded_json);
+    Py_VISIT(state->JSON_attr_is_finite);
+    Py_VISIT(state->JSON_attr_is_nan);
     Py_VISIT(state->RawJSONType);
     Py_VISIT(state->JSONDecodeError);
     return 0;

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -2850,14 +2850,35 @@ encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
     PyObject *encoded;
     Py_ssize_t len;
     int negative;
-    Py_UCS4 c;
+    JSON_UNICHR c;
+#if PY_MAJOR_VERSION >= 3
+    int kind;
+    void *data;
+#else
+    const char *data;
+#endif
     if (str == NULL)
         return NULL;
+#if PY_MAJOR_VERSION >= 3
+    if (PyUnicode_READY(str)) {
+        Py_DECREF(str);
+        return NULL;
+    }
     len = PyUnicode_GET_LENGTH(str);
-    negative = (len > 0 && PyUnicode_READ_CHAR(str, 0) == '-');
-    c = (Py_UCS4)0;
+    kind = PyUnicode_KIND(str);
+    data = PyUnicode_DATA(str);
+    negative = (len > 0 && PyUnicode_READ(kind, data, 0) == '-');
+    c = (JSON_UNICHR)0;
     if (len > (negative ? 1 : 0))
-        c = PyUnicode_READ_CHAR(str, negative ? 1 : 0);
+        c = PyUnicode_READ(kind, data, negative ? 1 : 0);
+#else
+    len = PyString_GET_SIZE(str);
+    data = PyString_AS_STRING(str);
+    negative = (len > 0 && data[0] == '-');
+    c = (JSON_UNICHR)0;
+    if (len > (negative ? 1 : 0))
+        c = (unsigned char)data[negative ? 1 : 0];
+#endif
     if (c <= '9') {
         /* First significant character is a digit (or unexpectedly empty):
            finite Decimal, emit as-is. */

--- a/simplejson/_speedups.c
+++ b/simplejson/_speedups.c
@@ -138,8 +138,6 @@ typedef struct {
     PyObject *JSON_attr_sort;         /* "sort" */
     PyObject *JSON_attr_encoded_json; /* "encoded_json" */
     PyObject *JSON_attr_add_note;     /* "add_note" (PEP 678, 3.11+) */
-    PyObject *JSON_attr_is_finite;    /* "is_finite" (Decimal, see #149) */
-    PyObject *JSON_attr_is_nan;       /* "is_nan" (Decimal, see #149) */
     PyObject *RawJSONType;
     PyObject *JSONDecodeError;
 } _speedups_state;
@@ -2834,20 +2832,6 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
     }
 }
 
-static int
-decimal_is_true_method(PyObject *obj, PyObject *method_name)
-{
-    /* Call a no-arg predicate method (is_finite/is_nan) on a Decimal and
-       return its truth value, or -1 on error. */
-    PyObject *res = PyObject_CallMethodObjArgs(obj, method_name, NULL);
-    int rv;
-    if (res == NULL)
-        return -1;
-    rv = PyObject_IsTrue(res);
-    Py_DECREF(res);
-    return rv;
-}
-
 static PyObject *
 encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
 {
@@ -2855,28 +2839,40 @@ encoder_encode_decimal(PyEncoderObject *s, PyObject *obj)
        stringified as-is (preserving precision and trailing zeros); non-finite
        Decimals (NaN, sNaN, Infinity) are routed through the same
        allow_nan/ignore_nan handling as floats so they never emit invalid
-       JSON. See https://github.com/simplejson/simplejson/issues/149 */
-    _speedups_state *state = get_speedups_state(s->module_ref);
+       JSON. See https://github.com/simplejson/simplejson/issues/149
+
+       str(Decimal) carries a leading '-' sign at most (never '+'); a finite
+       value's first significant character is always a digit while a non-finite
+       value's is a letter ('N'/'s' for [s]NaN, 'I' for Infinity). So a single
+       str() plus a one/two character check distinguishes the two. */
+    PyObject *str = PyObject_Str(obj);
     PyObject *floatobj;
     PyObject *encoded;
-    int is_finite;
-    int is_nan;
-    is_finite = decimal_is_true_method(obj, state->JSON_attr_is_finite);
-    if (is_finite < 0)
+    Py_ssize_t len;
+    int negative;
+    Py_UCS4 c;
+    if (str == NULL)
         return NULL;
-    if (is_finite)
-        return PyObject_Str(obj);
-    /* Non-finite: map to the equivalent float. float(Decimal('sNaN'))
-       raises, so signaling (and quiet) NaNs are mapped to a plain NaN;
-       infinities convert cleanly. */
-    is_nan = decimal_is_true_method(obj, state->JSON_attr_is_nan);
-    if (is_nan < 0)
-        return NULL;
-    if (is_nan) {
-        floatobj = PyFloat_FromDouble(Py_NAN);
+    len = PyUnicode_GET_LENGTH(str);
+    negative = (len > 0 && PyUnicode_READ_CHAR(str, 0) == '-');
+    c = (Py_UCS4)0;
+    if (len > (negative ? 1 : 0))
+        c = PyUnicode_READ_CHAR(str, negative ? 1 : 0);
+    if (c <= '9') {
+        /* First significant character is a digit (or unexpectedly empty):
+           finite Decimal, emit as-is. */
+        return str;
+    }
+    /* Non-finite Decimal; map to the equivalent float and let
+       encoder_encode_float apply allow_nan/ignore_nan. float(Decimal('sNaN'))
+       raises, so both quiet and signaling NaN ('N'/'s') map to a plain NaN;
+       'I' is an infinity carrying the sign already parsed above. */
+    Py_DECREF(str);
+    if (c == 'I') {
+        floatobj = PyFloat_FromDouble(negative ? -Py_HUGE_VAL : Py_HUGE_VAL);
     }
     else {
-        floatobj = PyNumber_Float(obj);
+        floatobj = PyFloat_FromDouble(Py_NAN);
     }
     if (floatobj == NULL)
         return NULL;
@@ -3801,8 +3797,6 @@ reset_speedups_state_constants(_speedups_state *state)
     Py_CLEAR(state->JSON_attr_sort);
     Py_CLEAR(state->JSON_attr_encoded_json);
     Py_CLEAR(state->JSON_attr_add_note);
-    Py_CLEAR(state->JSON_attr_is_finite);
-    Py_CLEAR(state->JSON_attr_is_nan);
     Py_CLEAR(state->RawJSONType);
     Py_CLEAR(state->JSONDecodeError);
 }
@@ -3908,12 +3902,6 @@ init_speedups_state(_speedups_state *state, PyObject *module)
     state->JSON_attr_add_note = JSON_InternFromString("add_note");
     if (state->JSON_attr_add_note == NULL)
         return -1;
-    state->JSON_attr_is_finite = JSON_InternFromString("is_finite");
-    if (state->JSON_attr_is_finite == NULL)
-        return -1;
-    state->JSON_attr_is_nan = JSON_InternFromString("is_nan");
-    if (state->JSON_attr_is_nan == NULL)
-        return -1;
 
     (void)module;
     return 0;
@@ -4001,8 +3989,6 @@ speedups_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(state->JSON_attr_asdict);
     Py_VISIT(state->JSON_attr_sort);
     Py_VISIT(state->JSON_attr_encoded_json);
-    Py_VISIT(state->JSON_attr_is_finite);
-    Py_VISIT(state->JSON_attr_is_nan);
     Py_VISIT(state->RawJSONType);
     Py_VISIT(state->JSONDecodeError);
     return 0;

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -61,14 +61,15 @@ def _encode_decimal(d, _floatstr):
     ``str()`` plus a one/two character check distinguishes the two.
     """
     s = str(d)
-    c = s[1] if s[0] == '-' else s[0]
-    if c <= '9':
+    c0 = s[:1]
+    c = s[1:2] if c0 == '-' else c0
+    if '0' <= c <= '9':
         # First significant character is a digit: finite Decimal.
         return s
     # Non-finite Decimal. ``N``/``s`` -> NaN (float(Decimal('sNaN')) raises,
     # so map both quiet and signaling NaN to a plain NaN); ``I`` -> Infinity.
     if c == 'I':
-        return _floatstr(-_INFINITY if s[0] == '-' else _INFINITY)
+        return _floatstr(-_INFINITY if c0 == '-' else _INFINITY)
     return _floatstr(_NAN)
 
 # dict-like types that should be encoded as JSON objects.

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -44,17 +44,32 @@ del i
 FLOAT_REPR = repr
 
 _NAN = float('nan')
+_INFINITY = float('inf')
 
 
-def _nonfinite_decimal_to_float(d):
-    """Map a non-finite ``Decimal`` to the equivalent ``float`` so that
-    ``NaN`` and ``Infinity`` follow the same ``allow_nan``/``ignore_nan``
-    handling as floats (see #149).  ``float(Decimal('sNaN'))`` raises, so
-    signaling NaNs are mapped to a plain NaN.
+def _encode_decimal(d, _floatstr):
+    """Return the JSON representation of a ``Decimal``.
+
+    Finite Decimals are stringified as-is, preserving precision and trailing
+    zeros.  Non-finite Decimals (``NaN``, ``sNaN``, ``Infinity``) are routed
+    through the same ``allow_nan``/``ignore_nan`` handling as floats so they
+    never emit invalid JSON (see #149).
+
+    ``str(Decimal)`` yields a leading ``-`` sign at most (never ``+``); a
+    finite value's first significant character is always a digit, while a
+    non-finite value's is a letter (``N``, ``s`` or ``I``).  So a single
+    ``str()`` plus a one/two character check distinguishes the two.
     """
-    if d.is_nan():
-        return _NAN
-    return float(d)
+    s = str(d)
+    c = s[1] if s[0] == '-' else s[0]
+    if c <= '9':
+        # First significant character is a digit: finite Decimal.
+        return s
+    # Non-finite Decimal. ``N``/``s`` -> NaN (float(Decimal('sNaN')) raises,
+    # so map both quiet and signaling NaN to a plain NaN); ``I`` -> Infinity.
+    if c == 'I':
+        return _floatstr(-_INFINITY if s[0] == '-' else _INFINITY)
+    return _floatstr(_NAN)
 
 # dict-like types that should be encoded as JSON objects.
 # frozendict is a builtin added in CPython 3.15 (PEP 814).
@@ -549,10 +564,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 elif isinstance(value, float):
                     yield buf + _floatstr(value)
                 elif _use_decimal and isinstance(value, Decimal):
-                    if value.is_finite():
-                        yield buf + str(value)
-                    else:
-                        yield buf + _floatstr(_nonfinite_decimal_to_float(value))
+                    yield buf + _encode_decimal(value, _floatstr)
                 else:
                     yield buf
                     for_json = _for_json and call_method(value, 'for_json')
@@ -612,10 +624,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 key = int(key)
             key = str(key)
         elif _use_decimal and isinstance(key, Decimal):
-            if key.is_finite():
-                key = str(key)
-            else:
-                key = _floatstr(_nonfinite_decimal_to_float(key))
+            key = _encode_decimal(key, _floatstr)
         elif _skipkeys:
             key = None
         else:
@@ -687,10 +696,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 elif isinstance(value, float):
                     yield _floatstr(value)
                 elif _use_decimal and isinstance(value, Decimal):
-                    if value.is_finite():
-                        yield str(value)
-                    else:
-                        yield _floatstr(_nonfinite_decimal_to_float(value))
+                    yield _encode_decimal(value, _floatstr)
                 else:
                     for_json = _for_json and call_method(value, 'for_json')
                     if for_json:
@@ -766,10 +772,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     for chunk in _iterencode_dict(o, _current_indent_level):
                         yield chunk
                 elif _use_decimal and isinstance(o, Decimal):
-                    if o.is_finite():
-                        yield str(o)
-                    else:
-                        yield _floatstr(_nonfinite_decimal_to_float(o))
+                    yield _encode_decimal(o, _floatstr)
                 else:
                     while _iterable_as_array:
                         # Markers are not checked here because it is valid for

--- a/simplejson/encoder.py
+++ b/simplejson/encoder.py
@@ -43,6 +43,19 @@ del i
 
 FLOAT_REPR = repr
 
+_NAN = float('nan')
+
+
+def _nonfinite_decimal_to_float(d):
+    """Map a non-finite ``Decimal`` to the equivalent ``float`` so that
+    ``NaN`` and ``Infinity`` follow the same ``allow_nan``/``ignore_nan``
+    handling as floats (see #149).  ``float(Decimal('sNaN'))`` raises, so
+    signaling NaNs are mapped to a plain NaN.
+    """
+    if d.is_nan():
+        return _NAN
+    return float(d)
+
 # dict-like types that should be encoded as JSON objects.
 # frozendict is a builtin added in CPython 3.15 (PEP 814).
 if sys.version_info >= (3, 15):
@@ -536,7 +549,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 elif isinstance(value, float):
                     yield buf + _floatstr(value)
                 elif _use_decimal and isinstance(value, Decimal):
-                    yield buf + str(value)
+                    if value.is_finite():
+                        yield buf + str(value)
+                    else:
+                        yield buf + _floatstr(_nonfinite_decimal_to_float(value))
                 else:
                     yield buf
                     for_json = _for_json and call_method(value, 'for_json')
@@ -596,7 +612,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 key = int(key)
             key = str(key)
         elif _use_decimal and isinstance(key, Decimal):
-            key = str(key)
+            if key.is_finite():
+                key = str(key)
+            else:
+                key = _floatstr(_nonfinite_decimal_to_float(key))
         elif _skipkeys:
             key = None
         else:
@@ -668,7 +687,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                 elif isinstance(value, float):
                     yield _floatstr(value)
                 elif _use_decimal and isinstance(value, Decimal):
-                    yield str(value)
+                    if value.is_finite():
+                        yield str(value)
+                    else:
+                        yield _floatstr(_nonfinite_decimal_to_float(value))
                 else:
                     for_json = _for_json and call_method(value, 'for_json')
                     if for_json:
@@ -744,7 +766,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     for chunk in _iterencode_dict(o, _current_indent_level):
                         yield chunk
                 elif _use_decimal and isinstance(o, Decimal):
-                    yield str(o)
+                    if o.is_finite():
+                        yield str(o)
+                    else:
+                        yield _floatstr(_nonfinite_decimal_to_float(o))
                 else:
                     while _iterable_as_array:
                         # Markers are not checked here because it is valid for

--- a/simplejson/tests/test_decimal.py
+++ b/simplejson/tests/test_decimal.py
@@ -69,3 +69,65 @@ class TestDecimal(TestCase):
         import simplejson.encoder
         simplejson.encoder.Decimal = Decimal
         self.test_decimal_roundtrip()
+
+    def test_decimal_nan_allow(self):
+        # Non-finite Decimals should be treated the same as the matching
+        # float, i.e. emit the JavaScript literals when allow_nan is true.
+        # https://github.com/simplejson/simplejson/issues/149
+        self.assertEqual(json.dumps(Decimal('NaN'), allow_nan=True), 'NaN')
+        self.assertEqual(
+            json.dumps(Decimal('Infinity'), allow_nan=True), 'Infinity')
+        self.assertEqual(
+            json.dumps(Decimal('-Infinity'), allow_nan=True), '-Infinity')
+        # sNaN is also not finite and must not leak through as a literal.
+        self.assertEqual(json.dumps(Decimal('sNaN'), allow_nan=True), 'NaN')
+
+    def test_decimal_nan_ignore(self):
+        # ignore_nan should emit null for non-finite Decimals, matching float.
+        # https://github.com/simplejson/simplejson/issues/149
+        for d in (Decimal('NaN'), Decimal('sNaN'),
+                  Decimal('Infinity'), Decimal('-Infinity')):
+            self.assertEqual(json.dumps(d, ignore_nan=True), 'null')
+        self.assertEqual(
+            json.dumps([Decimal('0.33'), Decimal('NaN'), Decimal('0.20')],
+                       ignore_nan=True),
+            '[0.33, null, 0.20]')
+
+    def test_decimal_nan_deny(self):
+        # allow_nan=False must raise for non-finite Decimals rather than
+        # silently emit invalid JSON.
+        # https://github.com/simplejson/simplejson/issues/149
+        for d in (Decimal('NaN'), Decimal('sNaN'),
+                  Decimal('Infinity'), Decimal('-Infinity')):
+            self.assertRaises(ValueError, json.dumps, d, allow_nan=False)
+        # allow_nan defaults to False, so a plain dumps must raise too.
+        self.assertRaises(ValueError, json.dumps, Decimal('NaN'))
+
+    def test_decimal_nan_as_value(self):
+        # Non-finite Decimals nested inside containers must be handled too.
+        self.assertEqual(
+            json.dumps({'a': Decimal('NaN')}, allow_nan=True), '{"a": NaN}')
+        self.assertEqual(
+            json.dumps({'a': Decimal('Infinity')}, ignore_nan=True),
+            '{"a": null}')
+        self.assertRaises(
+            ValueError, json.dumps, [Decimal('NaN')], allow_nan=False)
+
+    def test_decimal_nan_as_key(self):
+        # A non-finite Decimal used as a dict key follows the same rules.
+        self.assertEqual(
+            json.dumps({Decimal('NaN'): 1}, allow_nan=True), '{"NaN": 1}')
+        self.assertEqual(
+            json.dumps({Decimal('Infinity'): 1}, ignore_nan=True),
+            '{"null": 1}')
+        self.assertRaises(
+            ValueError, json.dumps, {Decimal('NaN'): 1}, allow_nan=False)
+
+    def test_decimal_finite_unaffected(self):
+        # The fix must not perturb finite Decimals, including zero and
+        # values that would lose trailing zeros if routed through float().
+        for s in ('0', '0.00', '-0', '1.50', '1E-30', '1234567890.1234567890'):
+            d = Decimal(s)
+            self.assertEqual(json.dumps(d), str(d))
+            self.assertEqual(json.dumps(d, ignore_nan=True), str(d))
+            self.assertEqual(json.dumps(d, allow_nan=True), str(d))


### PR DESCRIPTION
## Summary

Fixes #149.

Non-finite `Decimal` values were not handled consistently with the
matching `float`. Both the pure-Python encoder and the C extension
serialized a `Decimal` by calling `str()` on it directly, bypassing the
`allow_nan` / `ignore_nan` handling that floats go through. The result
was invalid JSON:

```python
>>> import simplejson, math
>>> from decimal import Decimal
>>> simplejson.dumps([Decimal('0.33'), Decimal('NaN'), Decimal('0.20')], ignore_nan=True)
'[0.33, NaN, 0.20]'                 # before: invalid; float gives [..., null, ...]
>>> simplejson.dumps(Decimal('NaN'), allow_nan=False)
'NaN'                               # before: invalid; float raises ValueError
```

## Fix

Non-finite `Decimal` values (`NaN`, `sNaN`, `Infinity`, `-Infinity`) are
now routed through the same float NaN/Inf handling (`floatstr` /
`encoder_encode_float`) as floats, so they follow `allow_nan` and
`ignore_nan` identically:

| mode | non-finite Decimal | matches float |
| --- | --- | --- |
| `allow_nan=True` | `NaN` / `Infinity` / `-Infinity` | yes |
| `ignore_nan=True` | `null` | yes |
| `allow_nan=False` (default) | raises `ValueError` | yes |

Finite `Decimal` values are left completely untouched — they are still
stringified as-is, so precision and trailing zeros (`0.00`, `1.50`,
`-0`) are preserved. This is why the fix keys on `is_finite()` rather
than the `is_normal()` suggestion from the issue thread: `is_normal()`
is `False` for `0`, `0.00` and subnormals, which would have routed them
through `float()` and dropped their trailing zeros.

`float(Decimal('sNaN'))` raises, so signaling NaNs are mapped to a plain
NaN before going through the float path.

### C path

The bug reproduces on **both** the C extension and the pure-Python
encoder (Decimal encoding goes through whichever encoder is active), so
the fix is applied to both. The C side adds a small
`encoder_encode_decimal` helper that mirrors the Python logic, using
cached interned `is_finite` / `is_nan` attribute names in the module
state (matching the existing `JSON_attr_*` pattern) with proper
GC `traverse`/`clear` wiring.

## Tests

Added regression tests to `simplejson/tests/test_decimal.py` covering
`allow_nan=True` / `ignore_nan=True` / `allow_nan=False` for non-finite
Decimals as top-level values, container values and dict keys, plus a
`test_decimal_finite_unaffected` guard confirming finite Decimals are
unchanged. The new tests fail on `main` and pass with the fix.

Verified locally with the `_cibw_runner` harness, which runs the full
suite twice — once with the C speedups loaded and once via
`NoExtensionTestSuite` (pure-Python): 458 tests pass on both paths, and
the extension wiring check (`c_make_encoder is make_encoder`) holds.
The C extension builds clean under the project's
`-Werror -Wdeclaration-after-statement` CFLAGS.

Also added a `CHANGES.txt` entry (under a provisional `4.1.2
(unreleased)` heading — happy to adjust the version/date to whatever
you prefer).

Disclosure: prepared with AI assistance; reviewed and verified locally.
