### PR TITLE
Report the comma position for illegal trailing comma errors

### DIFF
--- a/simplejson/_speedups_scan.h
+++ b/simplejson/_speedups_scan.h
@@ -204,6 +204,7 @@ JSON_SCAN_FN(_parse_object)(PyScannerObject *s, PyObject *pystr,
     /* only loop if the object is non-empty */
     if (idx <= end_idx && JSON_SCAN_READ(idx) != '}') {
         int trailing_delimiter = 0;
+        Py_ssize_t comma_idx = 0;
         while (idx <= end_idx) {
             trailing_delimiter = 0;
 
@@ -271,6 +272,7 @@ JSON_SCAN_FN(_parse_object)(PyScannerObject *s, PyObject *pystr,
                 raise_errmsg(state, ERR_OBJECT_DELIMITER, pystr, idx);
                 goto bail;
             }
+            comma_idx = idx;
             idx++;
 
             /* skip whitespace after , delimiter */
@@ -279,7 +281,7 @@ JSON_SCAN_FN(_parse_object)(PyScannerObject *s, PyObject *pystr,
 
             /* check for trailing comma before } */
             if (idx <= end_idx && JSON_SCAN_READ(idx) == '}') {
-                raise_errmsg(state, ERR_TRAILING_COMMA_OBJECT, pystr, idx);
+                raise_errmsg(state, ERR_TRAILING_COMMA_OBJECT, pystr, comma_idx);
                 goto bail;
             }
         }
@@ -351,6 +353,7 @@ JSON_SCAN_FN(_parse_array)(PyScannerObject *s, PyObject *pystr,
     /* only loop if the array is non-empty */
     if (idx <= end_idx && JSON_SCAN_READ(idx) != ']') {
         int trailing_delimiter = 0;
+        Py_ssize_t comma_idx = 0;
         while (idx <= end_idx) {
             trailing_delimiter = 0;
             /* read any JSON term and de-tuplefy the (rval, idx) */
@@ -377,6 +380,7 @@ JSON_SCAN_FN(_parse_array)(PyScannerObject *s, PyObject *pystr,
                 raise_errmsg(state, ERR_ARRAY_DELIMITER, pystr, idx);
                 goto bail;
             }
+            comma_idx = idx;
             idx++;
 
             /* skip whitespace after , */
@@ -385,7 +389,7 @@ JSON_SCAN_FN(_parse_array)(PyScannerObject *s, PyObject *pystr,
 
             /* check for trailing comma before ] */
             if (idx <= end_idx && JSON_SCAN_READ(idx) == ']') {
-                raise_errmsg(state, ERR_TRAILING_COMMA_ARRAY, pystr, idx);
+                raise_errmsg(state, ERR_TRAILING_COMMA_ARRAY, pystr, comma_idx);
                 goto bail;
             }
         }

--- a/simplejson/decoder.py
+++ b/simplejson/decoder.py
@@ -213,6 +213,7 @@ def JSONObject(state, encoding, strict, scan_once, object_hook,
             break
         elif nextchar != ',':
             raise JSONDecodeError("Expecting ',' delimiter or '}'", s, end - 1)
+        comma_idx = end - 1
 
         try:
             nextchar = s[end]
@@ -230,7 +231,7 @@ def JSONObject(state, encoding, strict, scan_once, object_hook,
             if nextchar == '}':
                 raise JSONDecodeError(
                     "Illegal trailing comma before end of object",
-                    s, end - 1)
+                    s, comma_idx)
             raise JSONDecodeError(
                 "Expecting property name enclosed in double quotes",
                 s, end - 1)
@@ -271,6 +272,7 @@ def JSONArray(state, scan_once, array_hook=None,
             break
         elif nextchar != ',':
             raise JSONDecodeError("Expecting ',' delimiter or ']'", s, end - 1)
+        comma_idx = end - 1
 
         try:
             if s[end] in _ws:
@@ -283,7 +285,7 @@ def JSONArray(state, scan_once, array_hook=None,
         if s[end:end + 1] == ']':
             raise JSONDecodeError(
                 "Illegal trailing comma before end of array",
-                s, end - 1)
+                s, comma_idx)
 
     if array_hook is not None:
         values = array_hook(values)

--- a/simplejson/tests/test_decode.py
+++ b/simplejson/tests/test_decode.py
@@ -165,6 +165,33 @@ class TestDecode(TestCase):
                 self.assertIn(expected_msg, str(e),
                     "Wrong error for %r: %s" % (doc, e))
 
+    def test_trailing_comma_position(self):
+        # The reported position is the comma itself, not the closing
+        # bracket and not whatever whitespace happens to precede it.
+        # Same positions as the stdlib json module. Runs on both the C
+        # and the pure-Python scanner.
+        test_cases = [
+            ('[42,]', 3),
+            ('[42, ]', 3),
+            ('[42,\n]', 3),
+            ('[123  , ]', 6),
+            ('{"spam":42,}', 10),
+            ('{"spam":42 , }', 11),
+            ('{"spam":42,\n}', 10),
+            ('[[1, 2],]', 7),
+            ('{"a": {"b": 1,},}', 13),
+        ]
+        for doc, expected_pos in test_cases:
+            try:
+                json.loads(doc)
+                self.fail("Expected JSONDecodeError for %r" % (doc,))
+            except json.JSONDecodeError as e:
+                self.assertEqual(doc[e.pos], ',',
+                    "Position %d of %r is %r, not the comma"
+                    % (e.pos, doc, doc[e.pos]))
+                self.assertEqual(e.pos, expected_pos,
+                    "Wrong position for %r: %d" % (doc, e.pos))
+
     def test_nonascii_digits_rejected(self):
         # Non-ASCII digits (e.g. fullwidth digits) must not be accepted
         # as JSON numbers. Matches CPython gh-125687.


### PR DESCRIPTION
Differential fuzzing of the C scanner against the pure-Python fallback (`_toggle_speedups`) found 61 divergences in 12,000 random decode inputs, all of them the position reported for an illegal trailing comma in an array:

```python
>>> simplejson.loads('[42, ]')
# C scanner:      ... line 1 column 6 (char 5)   <- the ']'
# Python scanner: ... line 1 column 5 (char 4)   <- the space before it
# stdlib json:    ... line 1 column 4 (char 3)   <- the comma
```

## Cause

`ERR_TRAILING_COMMA_*` is raised after the whitespace following the comma has been skipped, so the index passed no longer refers to it. The C scanner passes `idx`, the closing bracket. `JSONArray` passes `end - 1`, an idiom copied from the delimiter error a few lines up where `end` had been incremented; here it has not, so the reported character is whatever precedes `]`.

## Fix

Capture the comma index when the delimiter is confirmed and report that, as `json/decoder.py` does with its own `comma_idx`. Four sites: `JSONObject`, `JSONArray`, and the object and array branches of the scan template. Trailing-comma detection landed in 4.0.0 as CPython parity (#371), so stdlib breaks the tie.

## Result

Same corpus: 61 divergences before, 0 after. Refiltering it to drop trailing commas gives 0 both before and after. Encode was fuzzed alongside and showed 0.

`test_trailing_comma_position` pins the offsets for both containers, whitespace after the comma, and nesting, and `_cibw_runner` runs it on both paths. Reverting only `decoder.py` fails it on the Python path, only `_speedups_scan.h` on the C path. Suite passes on both (460 tests, was 458). The C change builds clean under the `-Werror` flags in AGENTS.md. I could not exercise the Py2 `_str` instantiation locally.
